### PR TITLE
Create struct for error values

### DIFF
--- a/base/src/errors.rs
+++ b/base/src/errors.rs
@@ -1,35 +1,102 @@
 #![allow(dead_code)]
+use core::convert::From;
+use core::num::{NonZeroU32, TryFromIntError};
+
 pub type Tpm2Rc = u32;
 pub type Tss2Rc = Tpm2Rc;
 
-pub const TSS2_RC_LAYER_SHIFT: u32 = 16;
-pub const TSS2_RC_LAYER_MASK: Tss2Rc = 0xFF << TSS2_RC_LAYER_SHIFT;
-pub const TSS2_MU_RC_LAYER: Tss2Rc = 9 << TSS2_RC_LAYER_SHIFT;
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct TpmError(pub NonZeroU32);
+impl TpmError {
+    const fn new_const(val: u32) -> Self {
+        match NonZeroU32::new(val) {
+            Some(val) => Self(val),
+            None => panic!("TpmError cannot be 0"),
+        }
+    }
 
-pub const TSS2_BASE_RC_GENERAL_FAILURE: Tss2Rc = 1;
-pub const TSS2_BASE_RC_NOT_IMPLEMENTED: Tss2Rc = 2;
-pub const TSS2_BASE_RC_BAD_CONTEXT: Tss2Rc = 3;
-pub const TSS2_BASE_RC_ABI_MISMATCH: Tss2Rc = 4;
-pub const TSS2_BASE_RC_BAD_REFERENCE: Tss2Rc = 5;
-pub const TSS2_BASE_RC_INSUFFICIENT_BUFFER: Tss2Rc = 6;
-pub const TSS2_BASE_RC_BAD_SEQUENCE: Tss2Rc = 7;
-pub const TSS2_BASE_RC_NO_CONNECTION: Tss2Rc = 8;
-pub const TSS2_BASE_RC_TRY_AGAIN: Tss2Rc = 9;
-pub const TSS2_BASE_RC_IO_ERROR: Tss2Rc = 10;
-pub const TSS2_BASE_RC_BAD_VALUE: Tss2Rc = 11;
-pub const TSS2_BASE_RC_NOT_PERMITTED: Tss2Rc = 12;
-pub const TSS2_BASE_RC_INVALID_SESSIONS: Tss2Rc = 13;
-pub const TSS2_BASE_RC_NO_DECRYPT_PARAM: Tss2Rc = 14;
-pub const TSS2_BASE_RC_NO_ENCRYPT_PARAM: Tss2Rc = 15;
-pub const TSS2_BASE_RC_BAD_SIZE: Tss2Rc = 16;
-pub const TSS2_BASE_RC_MALFORMED_RESPONSE: Tss2Rc = 17;
-pub const TSS2_BASE_RC_INSUFFICIENT_CONTEXT: Tss2Rc = 18;
-pub const TSS2_BASE_RC_INSUFFICIENT_RESPONSE: Tss2Rc = 19;
+    const TSS2_RC_LAYER_SHIFT_VAL: u32 = 16;
+    pub const TSS2_RC_LAYER_SHIFT: TpmError = TpmError::new_const(Self::TSS2_RC_LAYER_SHIFT_VAL);
+    pub const TSS2_RC_LAYER_MASK: TpmError =
+        TpmError::new_const(0xFF << Self::TSS2_RC_LAYER_SHIFT_VAL);
+    const TSS2_MU_RC_LAYER_VAL: u32 = 9 << Self::TSS2_RC_LAYER_SHIFT_VAL;
+    pub const TSS2_MU_RC_LAYER: TpmError = TpmError::new_const(Self::TSS2_MU_RC_LAYER_VAL);
 
-pub const TSS2_MU_RC_INSUFFICIENT_BUFFER: Tss2Rc =
-    TSS2_MU_RC_LAYER | TSS2_BASE_RC_INSUFFICIENT_BUFFER;
-pub const TSS2_MU_RC_BAD_SIZE: Tss2Rc = TSS2_MU_RC_LAYER | TSS2_BASE_RC_BAD_SIZE;
+    pub const TSS2_BASE_RC_GENERAL_FAILURE: TpmError = TpmError::new_const(1);
+    pub const TSS2_BASE_RC_NOT_IMPLEMENTED: TpmError = TpmError::new_const(2);
+    pub const TSS2_BASE_RC_BAD_CONTEXT: TpmError = TpmError::new_const(3);
+    pub const TSS2_BASE_RC_ABI_MISMATCH: TpmError = TpmError::new_const(4);
+    pub const TSS2_BASE_RC_BAD_REFERENCE: TpmError = TpmError::new_const(5);
+    const TSS2_BASE_RC_INSUFFICIENT_BUFFER_VAL: u32 = 6;
+    pub const TSS2_BASE_RC_INSUFFICIENT_BUFFER: TpmError =
+        TpmError::new_const(Self::TSS2_BASE_RC_INSUFFICIENT_BUFFER_VAL);
+    pub const TSS2_BASE_RC_BAD_SEQUENCE: TpmError = TpmError::new_const(7);
+    pub const TSS2_BASE_RC_NO_CONNECTION: TpmError = TpmError::new_const(8);
+    pub const TSS2_BASE_RC_TRY_AGAIN: TpmError = TpmError::new_const(9);
+    pub const TSS2_BASE_RC_IO_ERROR: TpmError = TpmError::new_const(10);
+    pub const TSS2_BASE_RC_BAD_VALUE: TpmError = TpmError::new_const(11);
+    pub const TSS2_BASE_RC_NOT_PERMITTED: TpmError = TpmError::new_const(12);
+    pub const TSS2_BASE_RC_INVALID_SESSIONS: TpmError = TpmError::new_const(13);
+    pub const TSS2_BASE_RC_NO_DECRYPT_PARAM: TpmError = TpmError::new_const(14);
+    pub const TSS2_BASE_RC_NO_ENCRYPT_PARAM: TpmError = TpmError::new_const(15);
+    const TSS2_BASE_RC_BAD_SIZE_VAL: u32 = 16;
+    pub const TSS2_BASE_RC_BAD_SIZE: TpmError =
+        TpmError::new_const(Self::TSS2_BASE_RC_BAD_SIZE_VAL);
+    pub const TSS2_BASE_RC_MALFORMED_RESPONSE: TpmError = TpmError::new_const(17);
+    pub const TSS2_BASE_RC_INSUFFICIENT_CONTEXT: TpmError = TpmError::new_const(18);
+    pub const TSS2_BASE_RC_INSUFFICIENT_RESPONSE: TpmError = TpmError::new_const(19);
 
-const TPM2_RC_FMT1: Tpm2Rc = 0x080;
-pub const TPM2_RC_SIZE: Tpm2Rc = TPM2_RC_FMT1 + 0x015;
-pub const TPM2_RC_SELECTOR: Tpm2Rc = TPM2_RC_FMT1 + 0x018;
+    pub const TSS2_MU_RC_INSUFFICIENT_BUFFER: TpmError = TpmError::new_const(
+        Self::TSS2_MU_RC_LAYER_VAL | Self::TSS2_BASE_RC_INSUFFICIENT_BUFFER_VAL,
+    );
+    pub const TSS2_MU_RC_BAD_SIZE: TpmError =
+        TpmError::new_const(Self::TSS2_MU_RC_LAYER_VAL | Self::TSS2_BASE_RC_BAD_SIZE_VAL);
+
+    const TPM2_RC_FMT1: u32 = 0x080;
+    pub const TPM2_RC_SIZE: TpmError = TpmError::new_const(Self::TPM2_RC_FMT1 + 0x015);
+    pub const TPM2_RC_SELECTOR: TpmError = TpmError::new_const(Self::TPM2_RC_FMT1 + 0x018);
+}
+
+impl From<core::num::NonZeroU32> for crate::TpmError {
+    fn from(val: core::num::NonZeroU32) -> Self {
+        crate::TpmError(val)
+    }
+}
+
+impl From<TpmError> for core::num::NonZeroU32 {
+    fn from(val: TpmError) -> Self {
+        val.0
+    }
+}
+
+impl From<TpmError> for u32 {
+    fn from(val: TpmError) -> Self {
+        core::num::NonZeroU32::from(val).get()
+    }
+}
+
+impl TryFrom<u32> for TpmError {
+    type Error = TryFromIntError;
+    fn try_from(val: u32) -> Result<Self, TryFromIntError> {
+        match NonZeroU32::try_from(val) {
+            Ok(val) => Ok(TpmError(val)),
+            Err(err) => Err(err),
+        }
+    }
+}
+
+pub type TpmResult<T> = Result<T, TpmError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_from() {
+        assert!(TpmError::try_from(0).is_err());
+        assert_eq!(
+            Ok(TpmError::TSS2_BASE_RC_BAD_SEQUENCE),
+            TpmError::try_from(7)
+        );
+    }
+}

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -376,23 +376,19 @@ pub union TpmuSchemeKeyedHash {
     pub null: TpmsEmpty,
 }
 impl TpmuSchemeKeyedHash {
-    fn try_marshal(
-        &self,
-        selector: TpmiAlgKeyedhashScheme,
-        buffer: &mut [u8],
-    ) -> Result<usize, Tpm2Rc> {
+    fn try_marshal(&self, selector: TpmiAlgKeyedhashScheme, buffer: &mut [u8]) -> TpmResult<usize> {
         match selector.get() {
             TPM2_ALG_HMAC => unsafe { self.hmac.try_marshal(buffer) },
             TPM2_ALG_XOR => unsafe { self.exclusive_or.try_marshal(buffer) },
             TPM2_ALG_NONE => Ok(0),
-            _ => Err(TPM2_RC_SELECTOR),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
         }
     }
 
     fn try_unmarshal(
         selector: TpmiAlgKeyedhashScheme,
         buffer: &mut UnmarshalBuf,
-    ) -> Result<Self, Tpm2Rc> {
+    ) -> TpmResult<Self> {
         match selector.get() {
             TPM2_ALG_HMAC => Ok(TpmuSchemeKeyedHash {
                 hmac: TpmsSchemeHmac::try_unmarshal(buffer)?,
@@ -401,7 +397,7 @@ impl TpmuSchemeKeyedHash {
                 exclusive_or: TpmsSchemeXor::try_unmarshal(buffer)?,
             }),
             TPM2_ALG_NONE => Ok(TpmuSchemeKeyedHash { null: TpmsEmpty {} }),
-            _ => Err(TPM2_RC_SELECTOR),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
         }
     }
 }
@@ -431,20 +427,17 @@ pub union TpmuSymKeyBits {
     pub null: TpmsEmpty,
 }
 impl TpmuSymKeyBits {
-    fn try_marshal(&self, selector: TpmiAlgSymObject, buffer: &mut [u8]) -> Result<usize, Tpm2Rc> {
+    fn try_marshal(&self, selector: TpmiAlgSymObject, buffer: &mut [u8]) -> TpmResult<usize> {
         match selector.get() {
             TPM2_ALG_AES => unsafe { self.aes.try_marshal(buffer) },
             TPM2_ALG_SM4 => unsafe { self.sm4.try_marshal(buffer) },
             TPM2_ALG_CAMELLIA => unsafe { self.camellia.try_marshal(buffer) },
             TPM2_ALG_XOR => unsafe { self.exclusive_or.try_marshal(buffer) },
             TPM2_ALG_NONE => Ok(0),
-            _ => Err(TPM2_RC_SELECTOR),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
         }
     }
-    fn try_unmarshal(
-        selector: TpmiAlgSymObject,
-        buffer: &mut UnmarshalBuf,
-    ) -> Result<Self, Tpm2Rc> {
+    fn try_unmarshal(selector: TpmiAlgSymObject, buffer: &mut UnmarshalBuf) -> TpmResult<Self> {
         match selector.get() {
             TPM2_ALG_AES => Ok(TpmuSymKeyBits {
                 aes: TpmiAesKeyBits::try_unmarshal(buffer)?,
@@ -459,7 +452,7 @@ impl TpmuSymKeyBits {
                 exclusive_or: TpmiAlgHash::try_unmarshal(buffer)?,
             }),
             TPM2_ALG_NONE => Ok(TpmuSymKeyBits { null: TpmsEmpty {} }),
-            _ => Err(TPM2_RC_SELECTOR),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
         }
     }
 }
@@ -475,19 +468,16 @@ pub union TpmuSymMode {
     pub null: TpmsEmpty,
 }
 impl TpmuSymMode {
-    fn try_marshal(&self, selector: TpmiAlgSymObject, buffer: &mut [u8]) -> Result<usize, Tpm2Rc> {
+    fn try_marshal(&self, selector: TpmiAlgSymObject, buffer: &mut [u8]) -> TpmResult<usize> {
         match selector.get() {
             TPM2_ALG_AES => unsafe { self.aes.try_marshal(buffer) },
             TPM2_ALG_SM4 => unsafe { self.sm4.try_marshal(buffer) },
             TPM2_ALG_CAMELLIA => unsafe { self.camellia.try_marshal(buffer) },
             TPM2_ALG_XOR | TPM2_ALG_NONE => Ok(0),
-            _ => Err(TPM2_RC_SELECTOR),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
         }
     }
-    fn try_unmarshal(
-        selector: TpmiAlgSymObject,
-        buffer: &mut UnmarshalBuf,
-    ) -> Result<Self, Tpm2Rc> {
+    fn try_unmarshal(selector: TpmiAlgSymObject, buffer: &mut UnmarshalBuf) -> TpmResult<Self> {
         match selector.get() {
             TPM2_ALG_AES => Ok(TpmuSymMode {
                 aes: TpmiAlgSymMode::try_unmarshal(buffer)?,
@@ -502,7 +492,7 @@ impl TpmuSymMode {
                 exclusive_or: TpmsEmpty {},
             }),
             TPM2_ALG_NONE => Ok(TpmuSymMode { null: TpmsEmpty {} }),
-            _ => Err(TPM2_RC_SELECTOR),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
         }
     }
 }
@@ -557,7 +547,7 @@ pub union TpmuAsymScheme {
     pub null: TpmsEmpty,
 }
 impl TpmuAsymScheme {
-    fn try_marshal(&self, selector: TpmiAlgAsymScheme, buffer: &mut [u8]) -> Result<usize, Tpm2Rc> {
+    fn try_marshal(&self, selector: TpmiAlgAsymScheme, buffer: &mut [u8]) -> TpmResult<usize> {
         match selector.get() {
             TPM2_ALG_ECDH => unsafe { self.ecdh.try_marshal(buffer) },
             TPM2_ALG_ECMQV => unsafe { self.ecmqv.try_marshal(buffer) },
@@ -568,13 +558,10 @@ impl TpmuAsymScheme {
             TPM2_ALG_ECSCHNORR => unsafe { self.ecschnorr.try_marshal(buffer) },
             TPM2_ALG_OAEP => unsafe { self.oaep.try_marshal(buffer) },
             TPM2_ALG_RSAES | TPM2_ALG_NONE => Ok(0),
-            _ => Err(TPM2_RC_SELECTOR),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
         }
     }
-    fn try_unmarshal(
-        selector: TpmiAlgAsymScheme,
-        buffer: &mut UnmarshalBuf,
-    ) -> Result<Self, Tpm2Rc> {
+    fn try_unmarshal(selector: TpmiAlgAsymScheme, buffer: &mut UnmarshalBuf) -> TpmResult<Self> {
         match selector.get() {
             TPM2_ALG_ECDH => Ok(TpmuAsymScheme {
                 ecdh: TpmsKeySchemeEcdh::try_unmarshal(buffer)?,
@@ -604,7 +591,7 @@ impl TpmuAsymScheme {
                 rsaes: TpmsEmpty {},
             }),
             TPM2_ALG_NONE => Ok(TpmuAsymScheme { null: TpmsEmpty {} }),
-            _ => Err(TPM2_RC_SELECTOR),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
         }
     }
 }
@@ -649,18 +636,18 @@ pub union TpmuKdfScheme {
     pub null: TpmsEmpty,
 }
 impl TpmuKdfScheme {
-    fn try_marshal(&self, selector: TpmiAlgKdf, buffer: &mut [u8]) -> Result<usize, Tpm2Rc> {
+    fn try_marshal(&self, selector: TpmiAlgKdf, buffer: &mut [u8]) -> TpmResult<usize> {
         match selector.get() {
             TPM2_ALG_MGF1 => unsafe { self.mgf1.try_marshal(buffer) },
             TPM2_ALG_KDF1_SP800_56A => unsafe { self.kdf1_sp800_56a.try_marshal(buffer) },
             TPM2_ALG_KDF2 => unsafe { self.kdf2.try_marshal(buffer) },
             TPM2_ALG_KDF1_SP800_108 => unsafe { self.kdf1_sp800_108.try_marshal(buffer) },
             TPM2_ALG_NONE => Ok(0),
-            _ => Err(TPM2_RC_SELECTOR),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
         }
     }
 
-    fn try_unmarshal(selector: TpmiAlgKdf, buffer: &mut UnmarshalBuf) -> Result<Self, Tpm2Rc> {
+    fn try_unmarshal(selector: TpmiAlgKdf, buffer: &mut UnmarshalBuf) -> TpmResult<Self> {
         match selector.get() {
             TPM2_ALG_MGF1 => Ok(TpmuKdfScheme {
                 mgf1: TpmsSchemeMgf1::try_unmarshal(buffer)?,
@@ -675,7 +662,7 @@ impl TpmuKdfScheme {
                 kdf1_sp800_108: TpmsSchemeKdf1Sp800_108::try_unmarshal(buffer)?,
             }),
             TPM2_ALG_NONE => Ok(TpmuKdfScheme { null: TpmsEmpty {} }),
-            _ => Err(TPM2_RC_SELECTOR),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
         }
     }
 }
@@ -722,16 +709,16 @@ pub union TpmuPublicParms {
     pub asym_detail: TpmsAsymParms,
 }
 impl TpmuPublicParms {
-    fn try_marshal(&self, selector: TpmiAlgPublic, buffer: &mut [u8]) -> Result<usize, Tpm2Rc> {
+    fn try_marshal(&self, selector: TpmiAlgPublic, buffer: &mut [u8]) -> TpmResult<usize> {
         match selector.get() {
             TPM2_ALG_KEYEDHASH => unsafe { self.keyed_hash_detail.try_marshal(buffer) },
             TPM2_ALG_SYMCIPHER => unsafe { self.sym_detail.try_marshal(buffer) },
             TPM2_ALG_RSA => unsafe { self.rsa_detail.try_marshal(buffer) },
             TPM2_ALG_ECC => unsafe { self.ecc_detail.try_marshal(buffer) },
-            _ => Err(TPM2_RC_SELECTOR),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
         }
     }
-    fn try_unmarshal(selector: TpmiAlgPublic, buffer: &mut UnmarshalBuf) -> Result<Self, Tpm2Rc> {
+    fn try_unmarshal(selector: TpmiAlgPublic, buffer: &mut UnmarshalBuf) -> TpmResult<Self> {
         match selector.get() {
             TPM2_ALG_KEYEDHASH => Ok(TpmuPublicParms {
                 keyed_hash_detail: TpmsKeyedHashParms::try_unmarshal(buffer)?,
@@ -745,7 +732,7 @@ impl TpmuPublicParms {
             TPM2_ALG_ECC => Ok(TpmuPublicParms {
                 ecc_detail: TpmsEccParms::try_unmarshal(buffer)?,
             }),
-            _ => Err(TPM2_RC_SELECTOR),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
         }
     }
 }
@@ -760,16 +747,16 @@ pub union TpmuPublicId {
     pub derive: TpmsDerive,
 }
 impl TpmuPublicId {
-    fn try_marshal(&self, selector: TpmiAlgPublic, buffer: &mut [u8]) -> Result<usize, Tpm2Rc> {
+    fn try_marshal(&self, selector: TpmiAlgPublic, buffer: &mut [u8]) -> TpmResult<usize> {
         match selector.get() {
             TPM2_ALG_KEYEDHASH => unsafe { self.keyed_hash.try_marshal(buffer) },
             TPM2_ALG_SYMCIPHER => unsafe { self.sym.try_marshal(buffer) },
             TPM2_ALG_RSA => unsafe { self.rsa.try_marshal(buffer) },
             TPM2_ALG_ECC => unsafe { self.ecc.try_marshal(buffer) },
-            _ => Err(TPM2_RC_SELECTOR),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
         }
     }
-    fn try_unmarshal(selector: TpmiAlgPublic, buffer: &mut UnmarshalBuf) -> Result<Self, Tpm2Rc> {
+    fn try_unmarshal(selector: TpmiAlgPublic, buffer: &mut UnmarshalBuf) -> TpmResult<Self> {
         match selector.get() {
             TPM2_ALG_KEYEDHASH => Ok(TpmuPublicId {
                 keyed_hash: Tpm2bDigest::try_unmarshal(buffer)?,
@@ -783,7 +770,7 @@ impl TpmuPublicId {
             TPM2_ALG_ECC => Ok(TpmuPublicId {
                 ecc: TpmsEccPoint::try_unmarshal(buffer)?,
             }),
-            _ => Err(TPM2_RC_SELECTOR),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
         }
     }
 }
@@ -940,7 +927,7 @@ pub trait Tpm2bSimple {
     const MAX_BUFFER_SIZE: usize;
     fn get_size(&self) -> u16;
     fn get_buffer(&self) -> &[u8];
-    fn from_bytes(buffer: &[u8]) -> Result<Self, Tpm2Rc>
+    fn from_bytes(buffer: &[u8]) -> TpmResult<Self>
     where
         Self: Sized;
 }
@@ -958,10 +945,10 @@ macro_rules! impl_try_marshalable_tpm2b_simple {
                 &self.$F[0..self.get_size() as usize]
             }
 
-            fn from_bytes(buffer: &[u8]) -> Result<Self, Tpm2Rc> {
+            fn from_bytes(buffer: &[u8]) -> TpmResult<Self> {
                 // Overflow check
                 if buffer.len() > core::cmp::min(u16::MAX as usize, Self::MAX_BUFFER_SIZE) {
-                    return Err(TSS2_MU_RC_BAD_SIZE);
+                    return Err(TpmError::TSS2_MU_RC_BAD_SIZE);
                 }
 
                 let mut dest: Self = Self {
@@ -974,12 +961,12 @@ macro_rules! impl_try_marshalable_tpm2b_simple {
         }
 
         impl Marshalable for $T {
-            fn try_unmarshal(buffer: &mut UnmarshalBuf) -> Result<Self, Tpm2Rc> {
+            fn try_unmarshal(buffer: &mut UnmarshalBuf) -> TpmResult<Self> {
                 let got_size = U16::try_unmarshal(buffer)?;
                 // Ensure the buffer is large enough to fullfill the size indicated
                 let sized_buffer = buffer.get(got_size.get() as usize);
                 if !sized_buffer.is_some() {
-                    return Err(TSS2_MU_RC_INSUFFICIENT_BUFFER);
+                    return Err(TpmError::TSS2_MU_RC_INSUFFICIENT_BUFFER);
                 }
 
                 let mut dest: Self = Self {
@@ -989,19 +976,19 @@ macro_rules! impl_try_marshalable_tpm2b_simple {
 
                 // Make sure the size indicated isn't too large for the types buffer
                 if sized_buffer.unwrap().len() > dest.$F.len() {
-                    return Err(TSS2_MU_RC_INSUFFICIENT_BUFFER);
+                    return Err(TpmError::TSS2_MU_RC_INSUFFICIENT_BUFFER);
                 }
                 dest.$F[..got_size.into()].copy_from_slice(&sized_buffer.unwrap());
 
                 Ok(dest)
             }
 
-            fn try_marshal(&self, buffer: &mut [u8]) -> Result<usize, Tpm2Rc> {
+            fn try_marshal(&self, buffer: &mut [u8]) -> TpmResult<usize> {
                 let used = self.size.try_marshal(buffer)?;
                 let (_, rest) = buffer.split_at_mut(used);
                 let buffer_marsh = self.get_size() as usize;
                 if buffer_marsh > (core::cmp::max(Self::MAX_BUFFER_SIZE, rest.len())) {
-                    return Err(TSS2_MU_RC_INSUFFICIENT_BUFFER);
+                    return Err(TpmError::TSS2_MU_RC_INSUFFICIENT_BUFFER);
                 }
                 rest[..buffer_marsh].copy_from_slice(&self.$F[..buffer_marsh]);
                 Ok(used + buffer_marsh)
@@ -1068,7 +1055,7 @@ mod tests {
             assert!(s.try_marshal(&mut bigger_size_buf).is_ok());
 
             // too small should fail
-            let mut result: Result<$T, Tpm2Rc> =
+            let mut result: TpmResult<$T> =
                 <$T>::try_unmarshal(&mut UnmarshalBuf::new(&too_small_size_buf));
             assert!(result.is_err());
 
@@ -1324,8 +1311,11 @@ mod tests {
 
         // Test invalid selector value.
         example.tipe = U16::new(TPM2_ALG_SHA256);
-        assert_eq!(example.try_marshal(&mut buffer), Err(TPM2_RC_SELECTOR));
+        assert_eq!(
+            example.try_marshal(&mut buffer),
+            Err(TpmError::TPM2_RC_SELECTOR)
+        );
         unmarsh = TpmtPublic::try_unmarshal(&mut UnmarshalBuf::new(&buffer));
-        assert_eq!(unmarsh.err(), Some(TPM2_RC_SELECTOR));
+        assert_eq!(unmarsh.err(), Some(TpmError::TPM2_RC_SELECTOR));
     }
 }

--- a/marshal_derive/src/lib.rs
+++ b/marshal_derive/src/lib.rs
@@ -35,13 +35,13 @@ pub fn derive_tpm_marshal(input: proc_macro::TokenStream) -> proc_macro::TokenSt
     let expanded = quote! {
         // The generated impl.
         impl Marshalable for #name  {
-            fn try_unmarshal(buffer: &mut UnmarshalBuf) -> Result<Self, Tss2Rc> {
+            fn try_unmarshal(buffer: &mut UnmarshalBuf) -> TpmResult<Self> {
                 #unmarshal_text;
                 Ok(#name{#field_list})
 
             }
 
-            fn try_marshal(&self, buffer: &mut [u8]) -> Result<usize, Tss2Rc> {
+            fn try_marshal(&self, buffer: &mut [u8]) -> TpmResult<usize> {
                 let mut written: usize = 0;
                 #marshal_text;
                 Ok(written)
@@ -180,7 +180,7 @@ fn get_unmarshal_body(data: &Data, _: &[Attribute]) -> TokenStream {
                             let usize_length = get_usize_length(&length, basic_field_types.get(length.get_ident().unwrap()));
                             quote_spanned! {f.span()=>
                                 if #usize_length > #max_size {
-                                    return Err(TPM2_RC_SIZE);
+                                    return Err(TpmError::TPM2_RC_SIZE);
                                 }
                                 let mut #name = [#entry_type::default(); #max_size];
                                 for i in #name.iter_mut().take(#usize_length) {


### PR DESCRIPTION
This will allow us to more robustly and clearly deal with error values versus simply using u32s. We are also able to enforce that no error value has an underlying u32 of 0 (which typically denotes success).

Fixes #12 