### PR TITLE
Extend example type approach to other structs

### DIFF
--- a/base/src/constants.rs
+++ b/base/src/constants.rs
@@ -54,3 +54,12 @@ pub const TPM2_ALG_KDF1_SP800_108: u16 = 0x0022;
 pub const TPM2_ALG_ECC: u16 = 0x0023;
 pub const TPM2_ALG_SYMCIPHER: u16 = 0x0025;
 pub const TPM2_ALG_CAMELLIA: u16 = 0x0026;
+
+/* Structure Tags */
+pub const TPM2_ST_ATTEST_NV: u16 = 0x8014;
+pub const TPM2_ST_ATTEST_COMMAND_AUDIT: u16 = 0x8015;
+pub const TPM2_ST_ATTEST_SESSION_AUDIT: u16 = 0x8016;
+pub const TPM2_ST_ATTEST_CERTIFY: u16 = 0x8017;
+pub const TPM2_ST_ATTEST_QUOTE: u16 = 0x8018;
+pub const TPM2_ST_ATTEST_TIME: u16 = 0x8019;
+pub const TPM2_ST_ATTEST_CREATION: u16 = 0x801A;

--- a/base/src/marshal.rs
+++ b/base/src/marshal.rs
@@ -265,4 +265,23 @@ mod tests {
         let unmarshal = Nameless::try_unmarshal(&mut UnmarshalBuf::new(&buffer));
         assert_eq!(value, unmarshal.unwrap());
     }
+
+    #[derive(PartialEq, Debug, Marshal)]
+    struct HasPlainArrayField {
+        a: u32,
+        b: [u8; 10],
+    }
+
+    #[test]
+    fn test_derive_array_field() {
+        let value = HasPlainArrayField {
+            a: 0x10101010,
+            b: [3, 4, 3, 4, 3, 4, 3, 4, 3, 4],
+        };
+        let mut buffer = [0u8; 16];
+        let marshal = value.try_marshal(&mut buffer);
+        assert!(marshal.is_ok());
+        let unmarshal = HasPlainArrayField::try_unmarshal(&mut UnmarshalBuf::new(&buffer));
+        assert_eq!(value, unmarshal.unwrap());
+    }
 }


### PR DESCRIPTION
This standardizes on BE types and enums with fields instead of unions. It also adds missing marshalable implementations and PartialEq/Debug derivations for all types.

A few union types remain that provide only size information. I don't think we need to provide marshaling for these, because the variant types can/should be marshaled directly instead.