### PR TITLE
Implement a Policy Calculator

### DIFF
--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 zerocopy = {version="0.7.0", features = ["derive"]}
 marshal_derive = { path = "../marshal_derive" }
 open-enum = "0.4.0"
+arrayvec = "0.7.4"

--- a/base/src/constants.rs
+++ b/base/src/constants.rs
@@ -5,12 +5,12 @@ use marshal_derive::Marshal;
 use open_enum::open_enum;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
-pub const TPM2_SHA_DIGEST_SIZE: u32 = 20;
-pub const TPM2_SHA1_DIGEST_SIZE: u32 = 20;
-pub const TPM2_SHA256_DIGEST_SIZE: u32 = 32;
-pub const TPM2_SHA384_DIGEST_SIZE: u32 = 48;
-pub const TPM2_SHA512_DIGEST_SIZE: u32 = 64;
-pub const TPM2_SM3_256_DIGEST_SIZE: u32 = 32;
+pub const TPM2_SHA_DIGEST_SIZE: usize = 20;
+pub const TPM2_SHA1_DIGEST_SIZE: usize = 20;
+pub const TPM2_SHA256_DIGEST_SIZE: usize = 32;
+pub const TPM2_SHA384_DIGEST_SIZE: usize = 48;
+pub const TPM2_SHA512_DIGEST_SIZE: usize = 64;
+pub const TPM2_SM3_256_DIGEST_SIZE: usize = 32;
 
 pub const TPM2_MAX_DIGEST_BUFFER: u32 = 1024;
 pub const TPM2_MAX_NV_BUFFER_SIZE: u32 = 2048;
@@ -231,13 +231,13 @@ pub enum TPM2RC {
     Failure = TPM2RC::RC_VER_1 + 0x001,
     Sequence = TPM2RC::RC_VER_1 + 0x003,
     Private = TPM2RC::RC_VER_1 + 0x00B,
-    HMAC = TPM2RC::RC_VER_1 + 0x019,
+    Hmac = TPM2RC::RC_VER_1 + 0x019,
     Disabled = TPM2RC::RC_VER_1 + 0x020,
     Exclusive = TPM2RC::RC_VER_1 + 0x021,
     AuthType = TPM2RC::RC_VER_1 + 0x024,
     AuthMissing = TPM2RC::RC_VER_1 + 0x025,
     Policy = TPM2RC::RC_VER_1 + 0x026,
-    PCR = TPM2RC::RC_VER_1 + 0x027,
+    Pcr = TPM2RC::RC_VER_1 + 0x027,
     PCRChanged = TPM2RC::RC_VER_1 + 0x028,
     Upgrade = TPM2RC::RC_VER_1 + 0x02D,
     TooManyContexts = TPM2RC::RC_VER_1 + 0x02E,
@@ -268,11 +268,11 @@ pub enum TPM2RC {
     Value = TPM2RC::RC_FMT_1 + 0x004,
     Hierarchy = TPM2RC::RC_FMT_1 + 0x005,
     KeySize = TPM2RC::RC_FMT_1 + 0x007,
-    MGF = TPM2RC::RC_FMT_1 + 0x008,
+    Mgf = TPM2RC::RC_FMT_1 + 0x008,
     Mode = TPM2RC::RC_FMT_1 + 0x009,
     Type = TPM2RC::RC_FMT_1 + 0x00A,
     Handle = TPM2RC::RC_FMT_1 + 0x00B,
-    KDF = TPM2RC::RC_FMT_1 + 0x00C,
+    Kdf = TPM2RC::RC_FMT_1 + 0x00C,
     Range = TPM2RC::RC_FMT_1 + 0x00D,
     AuthFail = TPM2RC::RC_FMT_1 + 0x00E,
     Nonce = TPM2RC::RC_FMT_1 + 0x00F,

--- a/base/src/hash.rs
+++ b/base/src/hash.rs
@@ -1,0 +1,84 @@
+use crate::{
+    constants::{
+        TPM2_SHA1_DIGEST_SIZE, TPM2_SHA256_DIGEST_SIZE, TPM2_SHA384_DIGEST_SIZE,
+        TPM2_SHA512_DIGEST_SIZE, TPM2_SM3_256_DIGEST_SIZE,
+    },
+    errors::{TpmError, TpmResult},
+};
+use arrayvec::ArrayVec;
+
+pub enum HashAlg {
+    Sha1,
+    Sha256,
+    Sha384,
+    Sha512,
+    Sm3_256,
+    // NOTE: If a larger length is added, MUST update HashAlg::MAX_ALG_LEN
+}
+
+impl HashAlg {
+    const MAX_ALG_LEN: Self = Self::Sha512;
+
+    pub const fn size(self) -> usize {
+        match self {
+            HashAlg::Sha1 => TPM2_SHA1_DIGEST_SIZE,
+            HashAlg::Sha256 => TPM2_SHA256_DIGEST_SIZE,
+            HashAlg::Sha384 => TPM2_SHA384_DIGEST_SIZE,
+            HashAlg::Sha512 => TPM2_SHA512_DIGEST_SIZE,
+            HashAlg::Sm3_256 => TPM2_SM3_256_DIGEST_SIZE,
+        }
+    }
+}
+
+/// A common base struct that can be used for all digests, signatures, and keys.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Digest(ArrayVec<u8, { Self::MAX_SIZE }>);
+
+impl Digest {
+    pub const MAX_SIZE: usize = HashAlg::MAX_ALG_LEN as usize;
+
+    pub fn new(bytes: &[u8]) -> TpmResult<Digest> {
+        let mut vec = ArrayVec::new();
+        vec.try_extend_from_slice(bytes)
+            .map_err(|_| TpmError::TPM2_RC_SIZE)?;
+        Ok(Digest(vec))
+    }
+
+    pub fn default(algs: HashAlg) -> Digest {
+        let mut vec = ArrayVec::new();
+        for _ in 0..algs.size() {
+            vec.push(0);
+        }
+        Digest(vec)
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.len() == 0
+    }
+}
+
+pub trait Hasher: Sized {
+    /// Initializes a Hasher object.
+    fn new() -> TpmResult<Self>;
+
+    /// Adds a chunk to the running hash.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes` - Value to add to hash.
+    fn update(&mut self, bytes: &[u8]) -> TpmResult<()>;
+
+    /// Finish a running hash operation and return the result.
+    ///
+    /// Once this function has been called, the object can no longer be used and
+    /// a new one must be created to hash more data.
+    fn finish(self) -> TpmResult<Digest>;
+}

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -108,7 +108,9 @@ const TPM2_MAX_TAGGED_POLICIES: usize = TPM2_MAX_CAP_DATA / size_of::<TpmsTagged
 pub mod commands;
 pub mod constants;
 pub mod errors;
+pub mod hash;
 pub mod marshal;
+pub mod policy;
 
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug, AsBytes, FromBytes, FromZeroes)]
@@ -117,20 +119,31 @@ pub struct TpmsEmpty;
 #[repr(C, u16)]
 #[derive(Clone, Copy, PartialEq, Debug, Marshal)]
 pub enum TpmtHa {
-    Sha1([u8; constants::TPM2_SHA_DIGEST_SIZE as usize]) = TPM2AlgID::SHA1.0,
-    Sha256([u8; constants::TPM2_SHA256_DIGEST_SIZE as usize]) = TPM2AlgID::SHA256.0,
-    Sha384([u8; constants::TPM2_SHA384_DIGEST_SIZE as usize]) = TPM2AlgID::SHA384.0,
-    Sha512([u8; constants::TPM2_SHA512_DIGEST_SIZE as usize]) = TPM2AlgID::SHA512.0,
-    Sm3_256([u8; constants::TPM2_SM3_256_DIGEST_SIZE as usize]) = TPM2AlgID::SM3256.0,
+    Sha1([u8; constants::TPM2_SHA_DIGEST_SIZE]) = TPM2AlgID::SHA1.0,
+    Sha256([u8; constants::TPM2_SHA256_DIGEST_SIZE]) = TPM2AlgID::SHA256.0,
+    Sha384([u8; constants::TPM2_SHA384_DIGEST_SIZE]) = TPM2AlgID::SHA384.0,
+    Sha512([u8; constants::TPM2_SHA512_DIGEST_SIZE]) = TPM2AlgID::SHA512.0,
+    Sm3_256([u8; constants::TPM2_SM3_256_DIGEST_SIZE]) = TPM2AlgID::SM3256.0,
 }
 impl TpmtHa {
     pub const fn union_size() -> usize {
         size_of::<TpmtHa>() - align_of::<TpmtHa>() - size_of::<u16>()
     }
+
+    pub const fn new(alg_id: TPM2AlgID) -> TpmResult<TpmtHa> {
+        match alg_id {
+            TPM2AlgID::SHA1 => Ok(TpmtHa::Sha1([0u8; TPM2_SHA1_DIGEST_SIZE])),
+            TPM2AlgID::SHA256 => Ok(TpmtHa::Sha256([0u8; TPM2_SHA256_DIGEST_SIZE])),
+            TPM2AlgID::SHA384 => Ok(TpmtHa::Sha384([0u8; TPM2_SHA384_DIGEST_SIZE])),
+            TPM2AlgID::SHA512 => Ok(TpmtHa::Sha512([0u8; TPM2_SHA512_DIGEST_SIZE])),
+            TPM2AlgID::SM3256 => Ok(TpmtHa::Sm3_256([0u8; TPM2_SM3_256_DIGEST_SIZE])),
+            _ => Err(TpmError::TPM2_RC_SELECTOR),
+        }
+    }
 }
 impl Default for TpmtHa {
     fn default() -> Self {
-        TpmtHa::Sha1([0; constants::TPM2_SHA1_DIGEST_SIZE as usize])
+        TpmtHa::Sha1([0; constants::TPM2_SHA1_DIGEST_SIZE])
     }
 }
 

--- a/base/src/policy.rs
+++ b/base/src/policy.rs
@@ -1,0 +1,101 @@
+use core::marker::PhantomData;
+
+use crate::{
+    errors::{TpmError, TpmResult},
+    hash::Hasher,
+    TPM2AlgID, TpmiAlgHash, TpmtHa, TPM2_SHA1_DIGEST_SIZE, TPM2_SHA256_DIGEST_SIZE,
+    TPM2_SHA384_DIGEST_SIZE, TPM2_SHA512_DIGEST_SIZE, TPM2_SM3_256_DIGEST_SIZE,
+};
+
+/// PolicyCalculator represents a TPM 2.0 policy that needs to be calculated
+/// synthetically (i.e., without a TPM).
+pub struct PolicyCalculator<H: Hasher> {
+    pub alg: TpmiAlgHash,
+    pub hash_state: TpmtHa,
+    phantom_data: PhantomData<H>,
+}
+
+impl<H: Hasher> PolicyCalculator<H> {
+    /// Creates a fresh policy using the given hash algorithm.
+    pub fn new(alg: TpmiAlgHash) -> TpmResult<Self> {
+        let hash_alg_id = alg.0.get();
+        let hash_state = TpmtHa::new(TPM2AlgID(hash_alg_id))?;
+
+        Ok(PolicyCalculator {
+            alg,
+            hash_state,
+            phantom_data: PhantomData,
+        })
+    }
+
+    /// Resets the internal state of the policy hash to all 0x0.
+    pub fn reset(&mut self) {
+        self.hash_state = match self.hash_state {
+            TpmtHa::Sha1(_) => TpmtHa::Sha1([0u8; TPM2_SHA1_DIGEST_SIZE]),
+            TpmtHa::Sha256(_) => TpmtHa::Sha256([0u8; TPM2_SHA256_DIGEST_SIZE]),
+            TpmtHa::Sha384(_) => TpmtHa::Sha384([0u8; TPM2_SHA384_DIGEST_SIZE]),
+            TpmtHa::Sha512(_) => TpmtHa::Sha512([0u8; TPM2_SHA512_DIGEST_SIZE]),
+            TpmtHa::Sm3_256(_) => TpmtHa::Sm3_256([0u8; TPM2_SM3_256_DIGEST_SIZE]),
+        };
+    }
+
+    /// Updates the internal state of the policy hash by appending the
+    /// current state with the given contents, and updating the new state
+    /// to the hash of that.
+    pub fn update(&mut self, bytes: &[u8]) -> TpmResult<()> {
+        let mut hasher = H::new()?;
+        self.hash_state = match self.hash_state {
+            TpmtHa::Sha1(state) => {
+                hasher.update(&[&state, bytes].concat())?;
+                let digest = hasher.finish()?;
+                TpmtHa::Sha1(
+                    digest.bytes()[..TPM2_SHA1_DIGEST_SIZE]
+                        .try_into()
+                        .map_err(|_| TpmError::TPM2_RC_SIZE)?,
+                )
+            }
+            TpmtHa::Sha256(state) => {
+                hasher.update(&[&state, bytes].concat())?;
+                let digest = hasher.finish()?;
+                TpmtHa::Sha256(
+                    digest.bytes()[..TPM2_SHA256_DIGEST_SIZE]
+                        .try_into()
+                        .map_err(|_| TpmError::TPM2_RC_SIZE)?,
+                )
+            }
+            TpmtHa::Sha384(state) => {
+                hasher.update(&[&state, bytes].concat())?;
+                let digest = hasher.finish()?;
+                TpmtHa::Sha384(
+                    digest.bytes()[..TPM2_SHA384_DIGEST_SIZE]
+                        .try_into()
+                        .map_err(|_| TpmError::TPM2_RC_SIZE)?,
+                )
+            }
+            TpmtHa::Sha512(state) => {
+                hasher.update(&[&state, bytes].concat())?;
+                let digest = hasher.finish()?;
+                TpmtHa::Sha512(
+                    digest.bytes()[..TPM2_SHA512_DIGEST_SIZE]
+                        .try_into()
+                        .map_err(|_| TpmError::TPM2_RC_SIZE)?,
+                )
+            }
+            TpmtHa::Sm3_256(state) => {
+                hasher.update(&[&state, bytes].concat())?;
+                let digest = hasher.finish()?;
+                TpmtHa::Sm3_256(
+                    digest.bytes()[..TPM2_SM3_256_DIGEST_SIZE]
+                        .try_into()
+                        .map_err(|_| TpmError::TPM2_RC_SIZE)?,
+                )
+            }
+        };
+        Ok(())
+    }
+
+    /// Returns the current state of the policy hash.
+    pub fn get_hash(&mut self) -> TpmtHa {
+        self.hash_state
+    }
+}


### PR DESCRIPTION
This policy calculator uses a hashing trait which supports various hashing algorithms and whose implementation will be given by the client.