### PR TITLE
Add BE marshaling for open_enum constants.

### DIFF
--- a/base/src/commands.rs
+++ b/base/src/commands.rs
@@ -4,7 +4,6 @@ use crate::{Marshalable, UnmarshalBuf};
 use crate::{TpmiYesNo, TpmlDigest, TpmlPcrSelection, TpmsCapabilityData};
 use marshal_derive::Marshal;
 use zerocopy::byteorder::big_endian::*;
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 // Provides a const way to turn a u32 into a U32.
 pub const fn to_be_u32(val: u32) -> U32 {
@@ -17,14 +16,14 @@ pub trait TpmCommand: Marshalable {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Marshal)]
 pub struct GetCapabilityCmd {
     capability: TPM2Cap,
     property: U32,
     property_count: U32,
 }
 impl TpmCommand for GetCapabilityCmd {
-    const CMD_CODE: TPM2CC = TPM2CC::PCRRead;
+    const CMD_CODE: TPM2CC = TPM2CC::GetCapability;
     type RespT = GetCapabilityResp;
 }
 

--- a/base/src/constants.rs
+++ b/base/src/constants.rs
@@ -1,9 +1,8 @@
 #![allow(dead_code)]
 
 use crate::{Marshalable, TpmResult, UnmarshalBuf};
-use marshal_derive::Marshal;
 use open_enum::open_enum;
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::big_endian::*;
 
 pub const TPM2_SHA_DIGEST_SIZE: u32 = 20;
 pub const TPM2_SHA1_DIGEST_SIZE: u32 = 20;
@@ -31,11 +30,28 @@ pub const TPM2_PRIVATE_VENDOR_SPECIFIC_BYTES: u32 = (TPM2_MAX_RSA_KEY_BYTES / 2)
 
 pub const TPM2_MAX_CONTEXT_SIZE: u32 = 5120;
 
+// Helper to marshal the primitive used for an open_enum in big-endian.
+// T is the open_enum type.
+// B is the big-endian type to {un}marshal as.
+macro_rules! impl_open_enum_marshalable {
+    ($T:ty, $B:ty) => {
+        impl Marshalable for $T {
+            fn try_marshal(&self, buffer: &mut [u8]) -> TpmResult<usize> {
+                <$B>::new(self.0).try_marshal(buffer)
+            }
+            fn try_unmarshal(buffer: &mut UnmarshalBuf) -> TpmResult<Self> {
+                Ok(Self(<$B>::try_unmarshal(buffer)?.get()))
+            }
+        }
+    };
+}
+
 // TPM2AlgID represents a TPM_ALG_ID.
 // See definition in Part 2: Structures, section 6.3.
 #[open_enum]
 #[repr(u16)]
-#[derive(Copy, Clone, Marshal, Default)]
+#[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
+#[derive(Copy, Clone, Default)]
 pub enum TPM2AlgID {
     RSA = 0x0001,
     TDES = 0x0003,
@@ -77,12 +93,13 @@ pub enum TPM2AlgID {
     CFB = 0x0043,
     ECB = 0x0044,
 }
+impl_open_enum_marshalable! {TPM2AlgID, U16}
 
 // TPM2ECCCurve represents a TPM_ECC_Curve.
 // See definition in Part 2: Structures, section 6.4.
 #[open_enum]
 #[repr(u16)]
-#[derive(Copy, Clone, AsBytes, FromBytes, FromZeroes, Default)]
+#[derive(Copy, Clone, Default)]
 pub enum TPM2ECCCurve {
     None = 0x0000,
     NistP192 = 0x0001,
@@ -94,12 +111,14 @@ pub enum TPM2ECCCurve {
     BNP638 = 0x0011,
     SM2P256 = 0x0020,
 }
+impl_open_enum_marshalable! {TPM2ECCCurve, U16}
 
 // TPM2CC represents a TPM_CC.
 // See definition in Part 2: Structures, section 6.5.2.
 #[open_enum]
-#[repr(u16)]
-#[derive(Copy, Clone, AsBytes, FromBytes, FromZeroes, Default)]
+#[repr(u32)]
+#[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
+#[derive(Copy, Clone, Default)]
 pub enum TPM2CC {
     NVUndefineSpaceSpecial = 0x0000011F,
     EvictControl = 0x00000120,
@@ -219,11 +238,12 @@ pub enum TPM2CC {
     CertifyX509 = 0x00000197,
     ACTSetTimeout = 0x00000198,
 }
+impl_open_enum_marshalable! {TPM2CC, U32}
 
 // TPM2RC represents a TPM_RC.
 // See definition in Part 2: Structures, section 6.6.
 #[open_enum]
-#[repr(u16)]
+#[repr(u32)]
 pub enum TPM2RC {
     Success = 0x00000000,
     // FMT0 error codes
@@ -231,13 +251,13 @@ pub enum TPM2RC {
     Failure = TPM2RC::RC_VER_1 + 0x001,
     Sequence = TPM2RC::RC_VER_1 + 0x003,
     Private = TPM2RC::RC_VER_1 + 0x00B,
-    HMAC = TPM2RC::RC_VER_1 + 0x019,
+    Hmac = TPM2RC::RC_VER_1 + 0x019,
     Disabled = TPM2RC::RC_VER_1 + 0x020,
     Exclusive = TPM2RC::RC_VER_1 + 0x021,
     AuthType = TPM2RC::RC_VER_1 + 0x024,
     AuthMissing = TPM2RC::RC_VER_1 + 0x025,
     Policy = TPM2RC::RC_VER_1 + 0x026,
-    PCR = TPM2RC::RC_VER_1 + 0x027,
+    Pcr = TPM2RC::RC_VER_1 + 0x027,
     PCRChanged = TPM2RC::RC_VER_1 + 0x028,
     Upgrade = TPM2RC::RC_VER_1 + 0x02D,
     TooManyContexts = TPM2RC::RC_VER_1 + 0x02E,
@@ -268,11 +288,11 @@ pub enum TPM2RC {
     Value = TPM2RC::RC_FMT_1 + 0x004,
     Hierarchy = TPM2RC::RC_FMT_1 + 0x005,
     KeySize = TPM2RC::RC_FMT_1 + 0x007,
-    MGF = TPM2RC::RC_FMT_1 + 0x008,
+    Mgf = TPM2RC::RC_FMT_1 + 0x008,
     Mode = TPM2RC::RC_FMT_1 + 0x009,
     Type = TPM2RC::RC_FMT_1 + 0x00A,
     Handle = TPM2RC::RC_FMT_1 + 0x00B,
-    KDF = TPM2RC::RC_FMT_1 + 0x00C,
+    Kdf = TPM2RC::RC_FMT_1 + 0x00C,
     Range = TPM2RC::RC_FMT_1 + 0x00D,
     AuthFail = TPM2RC::RC_FMT_1 + 0x00E,
     Nonce = TPM2RC::RC_FMT_1 + 0x00F,
@@ -325,13 +345,14 @@ pub enum TPM2RC {
     Retry = TPM2RC::RC_WARN + 0x022,
     NVUnavailable = TPM2RC::RC_WARN + 0x023,
 }
+impl_open_enum_marshalable! {TPM2RC, U32}
 
 impl TPM2RC {
-    pub const RC_VER_1: u16 = 0x00000100;
-    pub const RC_FMT_1: u16 = 0x00000080;
-    pub const RC_WARN: u16 = 0x00000900;
-    pub const RC_P: u16 = 0x00000040;
-    pub const RC_S: u16 = 0x00000800;
+    pub const RC_VER_1: u32 = 0x00000100;
+    pub const RC_FMT_1: u32 = 0x00000080;
+    pub const RC_WARN: u32 = 0x00000900;
+    pub const RC_P: u32 = 0x00000040;
+    pub const RC_S: u32 = 0x00000800;
 }
 
 // TPM2EO represents a TPM_EO.
@@ -352,12 +373,14 @@ pub enum TPM2EO {
     BitSet = 0x000A,
     BitClear = 0x000B,
 }
+impl_open_enum_marshalable! {TPM2EO, U16}
 
 // TPM2ST represents a TPM_ST.
 // See definition in Part 2: Structures, section 6.9.
 #[open_enum]
 #[repr(u16)]
-#[derive(Copy, Clone, AsBytes, FromBytes, FromZeroes, Default)]
+#[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
+#[derive(Copy, Clone, Default)]
 pub enum TPM2ST {
     RspCommand = 0x00C4,
     Null = 0x8000,
@@ -378,6 +401,7 @@ pub enum TPM2ST {
     AuthSigned = 0x8025,
     FuManifest = 0x8029,
 }
+impl_open_enum_marshalable! {TPM2ST, U16}
 
 // TPM2SU represents a TPM_SU.
 // See definition in Part 2: Structures, section 6.10.
@@ -387,11 +411,12 @@ pub enum TPM2SU {
     Clear = 0x0000,
     State = 0x0001,
 }
+impl_open_enum_marshalable! {TPM2SU, U16}
 
 // TPM2SE represents a TPM_SE.
 // See definition in Part 2: Structures, section 6.11.
 #[open_enum]
-#[repr(u16)]
+#[repr(u8)]
 pub enum TPM2SE {
     HMAC = 0x00,
     Policy = 0x01,
@@ -402,7 +427,7 @@ pub enum TPM2SE {
 // See definition in Part 2: Structures, section 6.12
 #[open_enum]
 #[repr(u32)]
-#[derive(Copy, Clone, AsBytes, FromBytes, FromZeroes, Default)]
+#[derive(Copy, Clone)]
 pub enum TPM2Cap {
     Algs = 0x00000000,
     Handles = 0x00000001,
@@ -416,12 +441,13 @@ pub enum TPM2Cap {
     AuthPolicies = 0x00000009,
     ACT = 0x0000000A,
 }
+impl_open_enum_marshalable! {TPM2Cap, U32}
 
 // TPM2PT represents a TPM_PT.
 // See definition in Part 2: Structures, section 6.13.
 #[open_enum]
-#[repr(u16)]
-#[derive(Copy, Clone, AsBytes, FromBytes, FromZeroes, Default)]
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
 pub enum TPM2PT {
     // a 4-octet character string containing the TPM Family value
     // (TPM_SPEC_FAMILY)
@@ -584,12 +610,13 @@ pub enum TPM2PT {
     // the low-order 32 bits of the command audit counter
     AuditCounter1 = 0x00000214,
 }
+impl_open_enum_marshalable! {TPM2PT, U32}
 
 // TPM2PTPCR represents a TPM_PT_PCR.
 // See definition in Part 2: Structures, section 6.14.
 #[open_enum]
-#[repr(u16)]
-#[derive(Copy, Clone, AsBytes, FromBytes, FromZeroes, Default)]
+#[repr(u32)]
+#[derive(Copy, Clone, Default)]
 pub enum TPM2PTPCR {
     // a SET bit in the TPMS_PCR_SELECT indicates that the PCR is saved and
     // restored by TPM_SU_STATE
@@ -637,11 +664,12 @@ pub enum TPM2PTPCR {
     // by an authorization value
     Auth = 0x00000014,
 }
+impl_open_enum_marshalable! {TPM2PTPCR, U32}
 
 // TPM2HT represents a TPM_HT.
 // See definition in Part 2: Structures, section 7.2.
 #[open_enum]
-#[repr(u16)]
+#[repr(u8)]
 pub enum TPM2HT {
     PCR = 0x00,
     NVIndex = 0x01,
@@ -657,7 +685,7 @@ pub enum TPM2HT {
 // See definition in Part 2: Structures, section 7.1.
 #[open_enum]
 #[repr(u32)]
-#[derive(Copy, Clone, AsBytes, FromBytes, FromZeroes, Default)]
+#[derive(Copy, Clone, Default)]
 pub enum TPM2Handle {
     RHOwner = 0x40000001,
     RHNull = 0x40000007,
@@ -667,11 +695,12 @@ pub enum TPM2Handle {
     RHPlatform = 0x4000000C,
     RHPlatformNV = 0x4000000D,
 }
+impl_open_enum_marshalable! {TPM2Handle, U32}
 
 // TPM2NT represents a TPM_NT.
 // See definition in Part 2: Structures, section 13.4.
 #[open_enum]
-#[repr(u16)]
+#[repr(u8)]
 pub enum TPM2NT {
     // contains data that is opaque to the TPM that can only be modified
     // using TPM2_NV_Write().

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -8,92 +8,92 @@ use zerocopy::byteorder::big_endian::*;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmaLocality(u8);
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct Tpm2KeyBits(U16);
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct Tpm2Generated(U32);
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmaNv(U32);
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
-pub struct TpmiAlgHash(U16);
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
+pub struct TpmiAlgHash(TPM2AlgID);
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
-pub struct TpmiAlgKdf(U16);
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
+pub struct TpmiAlgKdf(TPM2AlgID);
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
-pub struct TpmiAlgPublic(U16);
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
+pub struct TpmiAlgPublic(TPM2AlgID);
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
-pub struct TpmiAlgSymMode(U16);
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
+pub struct TpmiAlgSymMode(TPM2AlgID);
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
-pub struct TpmiAlgSymObject(U16);
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
+pub struct TpmiAlgSymObject(TPM2AlgID);
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
-pub struct TpmiAlgKeyedhashScheme(U16);
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
+pub struct TpmiAlgKeyedhashScheme(TPM2AlgID);
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
-pub struct TpmiAlgRsaScheme(U16);
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
+pub struct TpmiAlgRsaScheme(TPM2AlgID);
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
-pub struct TpmiAlgEccScheme(U16);
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
+pub struct TpmiAlgEccScheme(TPM2AlgID);
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
-pub struct TpmiAlgAsymScheme(U16);
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
+pub struct TpmiAlgAsymScheme(TPM2AlgID);
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiRhNvIndex(U32);
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiEccCurve(U16);
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiYesNo(u8);
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiStAttest(U16);
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiAesKeyBits(U16);
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiSm4KeyBits(U16);
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiCamelliaKeyBits(U16);
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiRsaKeyBits(U16);
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmaObject(U32);
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmaAlgorithm(U32);
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmaCc(U32);
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, AsBytes, FromBytes, FromZeroes)]
-pub struct TpmiStCommandTag(pub U16);
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
+pub struct TpmiStCommandTag(pub TPM2ST);
 
 const TPM2_MAX_CAP_DATA: usize =
     TPM2_MAX_CAP_BUFFER as usize - size_of::<TPM2Cap>() - size_of::<u32>();
@@ -464,7 +464,7 @@ pub struct Tpm2bEncryptedSecret {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshal)]
 pub struct TpmsSchemeXor {
     pub hash_alg: TpmiAlgHash,
     pub kdf: TpmiAlgKdf,
@@ -503,7 +503,7 @@ pub struct TpmsSymCipherParms {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, AsBytes, FromBytes, FromZeroes)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshal)]
 pub struct TpmsSchemeHash {
     pub hash_alg: TpmiAlgHash,
 }
@@ -1247,7 +1247,7 @@ mod tests {
     #[test]
     fn test_marshal_enum_override() {
         let hmac = TpmsSchemeHmac {
-            hash_alg: TpmiAlgHash(U16::new(0xB)),
+            hash_alg: TpmiAlgHash(TPM2AlgID::SHA256),
         };
         let scheme = TpmtKeyedHashScheme::Hmac(hmac);
         let mut buffer = [0u8; size_of::<TpmtKeyedHashScheme>()];
@@ -1257,13 +1257,13 @@ mod tests {
     #[test]
     fn test_marshal_tpmt_public() {
         let xor_sym_def_obj =
-            TpmtSymDefObject::ExclusiveOr(TpmiAlgHash(U16::new(TPM2AlgID::SHA256.0)), TpmsEmpty {});
+            TpmtSymDefObject::ExclusiveOr(TpmiAlgHash(TPM2AlgID::SHA256), TpmsEmpty {});
         let mut buffer = [0u8; size_of::<TpmtSymDefObject>()];
         let mut marsh = xor_sym_def_obj.try_marshal(&mut buffer);
         // Because XOR does not populate TpmuSymMode, we have bytes left over.
         assert!(marsh.unwrap() < buffer.len());
         let rsa_scheme = TpmtRsaScheme::Ecdsa(TpmsSigSchemeEcdsa {
-            hash_alg: TpmiAlgHash(U16::from(TPM2AlgID::SHA256.0)),
+            hash_alg: TpmiAlgHash(TPM2AlgID::SHA256),
         });
 
         let rsa_parms = TpmsRsaParms {
@@ -1277,7 +1277,7 @@ mod tests {
         let pubkey = Tpm2bPublicKeyRsa::from_bytes(&pubkey_buf).unwrap();
 
         let example = TpmtPublic {
-            name_alg: TpmiAlgHash(U16::new(TPM2AlgID::SHA256.0)),
+            name_alg: TpmiAlgHash(TPM2AlgID::SHA256),
             object_attributes: TpmaObject(U32::new(6543)),
             auth_policy: Tpm2bDigest::from_bytes(&[2, 2, 4, 4]).unwrap(),
             parms_and_id: PublicParmsAndId::Rsa(rsa_parms, pubkey),

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 zerocopy = {version="0.7.0", features = ["derive"]}
 tpm2-rs-base = { path = "../base" }
+marshal_derive = { path = "../marshal_derive" }


### PR DESCRIPTION
This fixes issues I ran into with constant byteswapping running against a simulator.