### PR TITLE
Switch to using aligned big-endian integers

### DIFF
--- a/base/src/big_endian.rs
+++ b/base/src/big_endian.rs
@@ -1,0 +1,65 @@
+//! Aligned big-endian integer primitives.
+//! 
+//! The structs here are similar to those defined in `zerocopy::byteorder`,
+//! but retain their alignment requirement, meaning reads are smaller.
+
+use core::fmt;
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
+
+macro_rules! impl_big_endian_ints {
+    ($($outer:ident => $inner:ty),* $(,)?) => {
+        $(
+            #[derive(Copy, Clone, Default, PartialEq, Eq, AsBytes, FromBytes, FromZeroes)]
+            #[repr(transparent)]
+            #[doc = concat!("An aligned big-endian `", stringify!($inner), "`.")]
+            pub struct $outer($inner);
+
+            impl fmt::Debug for $outer {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    f.debug_tuple(stringify!($outer)).field(&self.get()).finish()
+                }
+            }
+
+            impl $outer {
+                pub const ZERO: Self = Self(0);
+
+                #[doc = concat!(
+                    "Constructs a big-endian `", stringify!(inner),
+                    "` from native endian, performing a byte swap if needed.")]
+                pub const fn new(val: $inner) -> $outer {
+                    $outer(val.to_be())
+                }
+
+                #[doc = concat!(
+                    "Retrieves the inner `", stringify!(inner),
+                    "` as native endian, performing a byte swap if needed.")]
+                pub const fn get(self) -> $inner {
+                    <$inner>::from_be(self.0)
+                }
+            }
+
+            impl From<$inner> for $outer {
+                fn from(x: $inner) -> $outer {
+                    $outer::new(x)
+                }
+            }
+
+            impl From<$outer> for $inner {
+                fn from(x: $outer) -> $inner {
+                    x.get()
+                }
+            }
+        )*
+    };
+}
+
+impl_big_endian_ints!(
+    U8 => u8,
+    U16 => u16,
+    U32 => u32,
+    U64 => u64,
+    I8 => i8,
+    I16 => i16,
+    I32 => i32,
+    I64 => i64,
+);

--- a/base/src/commands.rs
+++ b/base/src/commands.rs
@@ -1,14 +1,10 @@
+
+use crate::big_endian::*;
 use crate::constants::{TPM2Cap, TPM2CC};
 use crate::errors::TpmResult;
 use crate::{Marshalable, UnmarshalBuf};
 use crate::{TpmiYesNo, TpmlDigest, TpmlPcrSelection, TpmsCapabilityData};
 use marshal_derive::Marshal;
-use zerocopy::byteorder::big_endian::*;
-
-// Provides a const way to turn a u32 into a U32.
-pub const fn to_be_u32(val: u32) -> U32 {
-    U32::from_bytes(val.to_be_bytes())
-}
 
 pub trait TpmCommand: Marshalable {
     const CMD_CODE: TPM2CC;

--- a/base/src/constants.rs
+++ b/base/src/constants.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 
+use crate::big_endian::*;
 use crate::{Marshalable, TpmResult, UnmarshalBuf};
 use open_enum::open_enum;
-use zerocopy::big_endian::*;
 
 pub const TPM2_SHA_DIGEST_SIZE: u32 = 20;
 pub const TPM2_SHA1_DIGEST_SIZE: u32 = 20;

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -1,10 +1,9 @@
 #![allow(dead_code, clippy::large_enum_variant)]
 #![cfg_attr(not(test), no_std)]
 
-use crate::{constants::*, errors::*, marshal::*};
+use crate::{big_endian::*, constants::*, errors::*, marshal::*};
 use core::mem::{align_of, size_of};
 use marshal_derive::Marshal;
-use zerocopy::byteorder::big_endian::*;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 #[repr(C)]
@@ -105,6 +104,7 @@ const TPM2_MAX_PCR_PROPERTIES: usize = TPM2_MAX_CAP_DATA / size_of::<TpmsTaggedP
 const TPM2_MAX_ECC_CURVES: usize = TPM2_MAX_CAP_DATA / size_of::<TPM2ECCCurve>();
 const TPM2_MAX_TAGGED_POLICIES: usize = TPM2_MAX_CAP_DATA / size_of::<TpmsTaggedPolicy>();
 
+pub mod big_endian;
 pub mod commands;
 pub mod constants;
 pub mod errors;
@@ -990,7 +990,7 @@ macro_rules! impl_try_marshalable_tpm2b_simple {
                 if sized_buffer.unwrap().len() > dest.$F.len() {
                     return Err(TpmError::TSS2_MU_RC_INSUFFICIENT_BUFFER);
                 }
-                dest.$F[..got_size.into()].copy_from_slice(&sized_buffer.unwrap());
+                dest.$F[..got_size.get().into()].copy_from_slice(&sized_buffer.unwrap());
 
                 Ok(dest)
             }


### PR DESCRIPTION
Aligned reads are smaller than unaligned reads, and the current code always does a copy when marshalling/unmarshalling. The "big endian" part of this is no change: it was already doing lazy byte swaps.

Fixes #34.