### PR TITLE
Build and run client integration tests in one step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Build container for simulator tests
-        run: cd client && docker build -t simulator_tests .
-
-      - name: Run integration tests against simulator
-        run: cd client && docker compose run simulator_tests
+      - name: Build container and run simulator tests in it
+        run: cd client && docker build -t simulator_tests . && docker compose run simulator_tests
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
This prevents github CI from cleaning artifacts we need to run the tests sucessfully.