### PR TITLE
Fix docker compose build location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build container and run simulator tests in it
-        run: cd client && docker build -t simulator_tests . && docker compose run simulator_tests
+        run: cd client && docker compose build && docker compose run simulator_tests
 
   fmt:
     name: Rustfmt

--- a/client/compose.yaml
+++ b/client/compose.yaml
@@ -1,6 +1,6 @@
 services:
   simulator_tests:
-    build: ../
+    build: .
     volumes:
        - ../:/tpm-rs
     # Simulator tests must be single-threaded because they use a single TCP port.


### PR DESCRIPTION
I *think* this was causing `compose` calls to look in the wrong location for the Dockerfile/image.