### PR TITLE
Replace repr(C) with transparent for tuple structs

### DIFF
--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -11,91 +11,91 @@ pub use tpm2_rs_marshal as marshal;
 pub mod commands;
 pub mod constants;
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmaLocality(u8);
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct Tpm2KeyBits(u16);
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct Tpm2Generated(u32);
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmaNv(u32);
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiAlgHash(TPM2AlgID);
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiAlgKdf(TPM2AlgID);
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiAlgPublic(TPM2AlgID);
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiAlgSymMode(TPM2AlgID);
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiAlgSymObject(TPM2AlgID);
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiAlgKeyedhashScheme(TPM2AlgID);
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiAlgRsaScheme(TPM2AlgID);
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiAlgEccScheme(TPM2AlgID);
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiAlgAsymScheme(TPM2AlgID);
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiRhNvIndex(u32);
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiEccCurve(u16);
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiYesNo(pub u8);
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiStAttest(u16);
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiAesKeyBits(u16);
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiSm4KeyBits(u16);
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiCamelliaKeyBits(u16);
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiRsaKeyBits(u16);
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmaObject(u32);
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmaAlgorithm(pub u32);
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmaCc(u32);
 
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiStCommandTag(pub TPM2ST);
 


### PR DESCRIPTION
This patch modifies all structs in the form of `struct Foo(Bar)` to be represented transparently instead of being represented as C structure, hence fixing a potential undefined behaviour.

This allows C-bindings to expect the inner datatype without being wrapped inside another struct. This might lead to some subtle ABI differences. For instance, some architectures treat C structs differently from integers for instance.

The other alternative is to replace `struct Foo(Bar)` with `struct Foo{inner: Bar}`, but there is no advantage in forcing C users to wrap every single integer value in a new structure.

For reference: According to Rust Function call ABI compatibility[1]:
```
if you have a C function that is defined to take a uint32_t:
        void some_function(uint32_t value) { .. }
It is incorrect to pass in a struct as that value, even if that struct is #[repr(C)] and has only one field:
        #[repr(C)]
        struct Foo { x: u32 }
        extern "C" some_function(Foo);
        some_function(Foo { x: 22 }); // Bad!
Instead, you should declare the struct with #[repr(transparent)], which specifies that Foo should use the ABI rules for its field type, u32.
...
...
(Note further that the Rust ABI is undefined and theoretically may vary from compiler revision to compiler revision.)
```

[1] https://rust-lang.github.io/unsafe-code-guidelines/layout/structs-and-tuples.html