### PR TITLE
Run CI on PR branch rather than PR target branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
-    types: [opened,closed,synchronize]
+  pull_request:
+    branches:
+      - main
 
 jobs:
   check:


### PR DESCRIPTION
I think this will surfact build/test/clippy errors properly on unmerged PRs.