### PR TITLE
Add helpers for 2B* types containing structs.

### DIFF
--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -1431,7 +1431,7 @@ impl_try_marshalable_tpm2b_simple! {Tpm2bCreationData, creation_data}
 
 /// Provides conversion to/from a struct type for TPM2B types that don't hold a bytes buffer.
 pub trait Tpm2bStruct: Tpm2bSimple {
-    type StructType: Marshalable + Sized;
+    type StructType: Marshalable;
 
     /// Marshals the value into the 2b holder.
     fn from_struct(val: &Self::StructType) -> TpmRcResult<Self>


### PR DESCRIPTION
These marshal the contained struct type (only) into/out of the sized-byte-array 2B representation. This means that the size variable will always hold the correct length for marshaling/unmarshaling.