### PR TITLE
Add skeleton session/handle support to client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 
 [workspace.dependencies]
 # Third party dependencies
+arrayvec = { version="0.7.4", default-features=false }
 bitflags = "2.4.2"
 hex-literal = { version = "0.4.1" }
 open-enum = "0.4.1"

--- a/base/src/commands.rs
+++ b/base/src/commands.rs
@@ -2,9 +2,16 @@ use crate::constants::{TPM2Cap, TPM2CC, TPM2PT, TPM2SU};
 use crate::{Marshal, Marshalable, UnmarshalBuf};
 use crate::{TpmiYesNo, TpmlDigest, TpmlPcrSelection, TpmsCapabilityData};
 
+/// Trait for a TPM command transaction.
 pub trait TpmCommand: Marshalable {
+    /// The command code.
     const CMD_CODE: TPM2CC;
+    /// The command handles type.
+    type Handles: Marshalable + Default;
+    /// The response parameters type.
     type RespT: Marshalable;
+    /// The reponse handles type.
+    type RespHandles: Marshalable;
 }
 
 #[repr(C)]
@@ -14,7 +21,9 @@ pub struct StartupCmd {
 }
 impl TpmCommand for StartupCmd {
     const CMD_CODE: TPM2CC = TPM2CC::Startup;
+    type Handles = ();
     type RespT = ();
+    type RespHandles = ();
 }
 
 #[repr(C)]
@@ -26,7 +35,9 @@ pub struct GetCapabilityCmd {
 }
 impl TpmCommand for GetCapabilityCmd {
     const CMD_CODE: TPM2CC = TPM2CC::GetCapability;
+    type Handles = ();
     type RespT = GetCapabilityResp;
+    type RespHandles = ();
 }
 
 #[repr(C)]
@@ -43,7 +54,9 @@ pub struct PcrReadCmd {
 }
 impl TpmCommand for PcrReadCmd {
     const CMD_CODE: TPM2CC = TPM2CC::PCRRead;
+    type Handles = ();
     type RespT = PcrReadResp;
+    type RespHandles = ();
 }
 
 #[repr(C)]

--- a/base/src/constants.rs
+++ b/base/src/constants.rs
@@ -28,6 +28,7 @@ pub const TPM2_MAX_RSA_KEY_BYTES: u32 = 512;
 pub const TPM2_PRIVATE_VENDOR_SPECIFIC_BYTES: u32 = (TPM2_MAX_RSA_KEY_BYTES / 2) * (3 + 2);
 
 pub const TPM2_MAX_CONTEXT_SIZE: u32 = 5120;
+pub const TPM2_MAX_ACTIVE_SESSIONS: u32 = 64;
 
 // TPM2AlgID represents a TPM_ALG_ID.
 // See definition in Part 2: Structures, section 6.3.
@@ -713,6 +714,23 @@ impl TpmHc {
     const HRNvIndex: TpmHc = TpmHc::new(TPM2HT::NVIndex);
     // TODO: Add remaining values and ranges, some of which are profile-dependent.
 
+    /// The first HMAC session.
+    pub const HmacSessionFirst: TpmHc = TpmHc::HRHMACSession;
+    /// The last HMAC session.
+    pub const HmacSessionLast: TpmHc = TpmHc(TpmHc::HRHMACSession.0 + TPM2_MAX_ACTIVE_SESSIONS - 1);
+    /// Returns true if the value is a valid HMAC session handle.
+    pub fn is_hmac_session(value: u32) -> bool {
+        (TpmHc::HmacSessionFirst.0..=TpmHc::HmacSessionLast.0).contains(&value)
+    }
+    /// The first policy session.
+    pub const PolicySessionFirst: TpmHc = TpmHc::HRPolicySession;
+    /// The last policy session.
+    pub const PolicySessionLast: TpmHc =
+        TpmHc(TpmHc::HRPolicySession.0 + TPM2_MAX_ACTIVE_SESSIONS - 1);
+    /// Returns true if the value is a valid policy session handle.
+    pub fn is_policy_session(value: u32) -> bool {
+        (TpmHc::PolicySessionFirst.0..=TpmHc::PolicySessionLast.0).contains(&value)
+    }
     /// The first persistent object.
     pub const PersistentFirst: TpmHc = TpmHc::HRPersistent;
     /// The last persistent object.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 tpm-simulator-tests = []
 
 [dependencies]
+arrayvec = { workspace = true }
 tpm2-rs-base = { workspace = true }
 tpm2-rs-marshal = { workspace = true }
 

--- a/client/feature/src/lib.rs
+++ b/client/feature/src/lib.rs
@@ -35,7 +35,6 @@ where
 mod tests {
     use super::*;
     use tpm2_rs_base::constants::{TPM2AlgID, TPM2ST};
-    use tpm2_rs_base::errors::TssTcsError;
     use tpm2_rs_base::marshal::Marshalable;
     use tpm2_rs_base::{
         TpmaAlgorithm, TpmiYesNo, TpmlAlgProperty, TpmlTaggedTpmProperty, TpmsAlgProperty,
@@ -44,13 +43,13 @@ mod tests {
 
     struct FakeTpm {
         len: usize,
-        response: [u8; MAX_RESP_SIZE],
+        response: [u8; RESP_BUFFER_SIZE],
     }
     impl Default for FakeTpm {
         fn default() -> Self {
             FakeTpm {
                 len: 0,
-                response: [0; MAX_RESP_SIZE],
+                response: [0; RESP_BUFFER_SIZE],
             }
         }
     }
@@ -62,11 +61,11 @@ mod tests {
                 rc: 0,
             };
             let off = tx_header.try_marshal(response)?;
-            let length = off + self.response.len();
+            let length = off + self.len;
             if length > response.len() {
-                return Err(TssTcsError::OutOfMemory.into());
+                return Err(TpmRcError::Size.into());
             }
-            response[off..length].copy_from_slice(&self.response);
+            response[off..length].copy_from_slice(&self.response[..self.len]);
             tx_header.size = length as u32;
             tx_header.try_marshal(response)?;
             Ok(())

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,20 +1,23 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(not(test), no_std)]
 use core::mem::size_of;
+use sessions::CmdSessions;
 use tpm2_rs_base::commands::*;
 use tpm2_rs_base::constants::{TPM2CC, TPM2ST};
 use tpm2_rs_base::errors::{TpmError, TpmResult, TssTcsError};
 use tpm2_rs_base::marshal::{Marshal, Marshalable, UnmarshalBuf};
-use tpm2_rs_base::TpmiStCommandTag;
+use tpm2_rs_base::{TpmiStCommandTag, TpmsAuthResponse};
 
-pub const MAX_CMD_SIZE: usize = 4096 - CmdHeader::wire_size();
-pub const MAX_RESP_SIZE: usize = 4096 - RespHeader::wire_size();
+pub const CMD_BUFFER_SIZE: usize = 4096;
+pub const RESP_BUFFER_SIZE: usize = 4096;
+
+pub mod sessions;
 
 pub trait Tpm {
     fn transact(&mut self, command: &[u8], response: &mut [u8]) -> TpmResult<()>;
 }
 
-pub fn get_capability<T: Tpm>(
+pub fn get_capability<T: Tpm + ?Sized>(
     tpm: &mut T,
     command: &GetCapabilityCmd,
 ) -> TpmResult<GetCapabilityResp> {
@@ -29,9 +32,13 @@ pub struct CmdHeader {
     code: TPM2CC,
 }
 impl CmdHeader {
-    // This could be generated, but it won't work once we add sessions.
-    const fn wire_size() -> usize {
-        size_of::<TpmiStCommandTag>() + size_of::<u32>() + size_of::<TPM2CC>()
+    fn new(has_sessions: bool, code: TPM2CC) -> CmdHeader {
+        let tag = if has_sessions {
+            TpmiStCommandTag::NoSessions
+        } else {
+            TpmiStCommandTag::Sessions
+        };
+        CmdHeader { tag, size: 0, code }
     }
 }
 
@@ -42,48 +49,106 @@ pub struct RespHeader {
     pub size: u32,
     pub rc: u32,
 }
-impl RespHeader {
-    // This could be generated, but it won't work once we add sessions.
-    const fn wire_size() -> usize {
-        size_of::<TPM2ST>() + size_of::<u32>() + size_of::<u32>()
-    }
-}
 
+/// Runs a command with default/unset handles.
 pub fn run_command<CmdT, T>(cmd: &CmdT, tpm: &mut T) -> TpmResult<CmdT::RespT>
 where
     CmdT: TpmCommand,
-    T: Tpm,
+    T: Tpm + ?Sized,
 {
-    let mut cmd_buffer = [0u8; MAX_CMD_SIZE + CmdHeader::wire_size()];
-    let (hdr_space, cmd_space) = cmd_buffer.split_at_mut(CmdHeader::wire_size());
-    let cmd_size = cmd.try_marshal(cmd_space)? + CmdHeader::wire_size();
-    let header = CmdHeader {
-        tag: TpmiStCommandTag::NoSessions,
-        size: cmd_size as u32,
-        code: CmdT::CMD_CODE,
-    };
-    let _ = header.try_marshal(hdr_space)?;
-    let mut resp_buffer = [0u8; MAX_RESP_SIZE + RespHeader::wire_size()];
-    tpm.transact(&cmd_buffer[..cmd_size], &mut resp_buffer)?;
-    let (hdr, resp) = resp_buffer.split_at(RespHeader::wire_size());
-    let mut unmarsh = UnmarshalBuf::new(hdr);
-    let rh = RespHeader::try_unmarshal(&mut unmarsh)?;
-    if let Ok(value) = TpmError::try_from(rh.rc) {
-        return TpmResult::Err(value);
+    Ok(run_command_with_handles(cmd, CmdT::Handles::default(), CmdSessions::default(), tpm)?.0)
+}
+
+/// Adds any command sessions to the command buffer.
+pub fn write_command_sessions(sessions: &CmdSessions, buffer: &mut [u8]) -> TpmResult<usize> {
+    if sessions.is_empty() {
+        return Ok(0);
     }
-    let resp_size = rh.size as usize - hdr.len();
-    if resp_size > resp.len() {
-        return Err(TssTcsError::OutOfMemory.into());
+    let mut auth_offset = size_of::<u32>();
+    for session in sessions {
+        // TODO: Support parameter encryption.
+        auth_offset += session
+            .get_auth_command()
+            .try_marshal(&mut buffer[auth_offset..])?;
     }
-    unmarsh = UnmarshalBuf::new(&resp[..(rh.size as usize - hdr.len())]);
-    // If there is a marshalling error, return a Tss layer error instead of a service level error
-    CmdT::RespT::try_unmarshal(&mut unmarsh).or(Err(TssTcsError::OutOfMemory.into()))
+    let auth_size = (auth_offset - size_of::<u32>()) as u32;
+    auth_size.try_marshal(buffer)?;
+    Ok(auth_offset)
+}
+
+/// Umarshals the response header and checks the contained response code.
+pub fn read_response_header(buffer: &[u8]) -> TpmResult<(RespHeader, usize)> {
+    let mut unmarsh = UnmarshalBuf::new(buffer);
+    let resp_header = RespHeader::try_unmarshal(&mut unmarsh)?;
+    if let Ok(error) = TpmError::try_from(resp_header.rc) {
+        return TpmResult::Err(error);
+    }
+    Ok((resp_header, buffer.len() - unmarsh.len()))
+}
+
+/// Unmarshals any response sessions.
+pub fn read_response_sessions(sessions: &CmdSessions, buffer: &mut UnmarshalBuf) -> TpmResult<()> {
+    for session in sessions {
+        // TODO: Support parameter decryption.
+        let auth = TpmsAuthResponse::try_unmarshal(buffer)?;
+        session.validate_auth_response(&auth)?;
+    }
+    Ok(())
+}
+
+/// Runs a command with provided handles and sessions.
+pub fn run_command_with_handles<CmdT, T>(
+    cmd: &CmdT,
+    cmd_handles: CmdT::Handles,
+    cmd_sessions: CmdSessions,
+    tpm: &mut T,
+) -> TpmResult<(CmdT::RespT, CmdT::RespHandles)>
+where
+    CmdT: TpmCommand,
+    T: Tpm + ?Sized,
+{
+    let mut cmd_buffer = [0u8; CMD_BUFFER_SIZE];
+    let mut cmd_header = CmdHeader::new(cmd_sessions.is_empty(), CmdT::CMD_CODE);
+    let mut written = cmd_header.try_marshal(&mut cmd_buffer)?;
+
+    written += cmd_handles.try_marshal(&mut cmd_buffer[written..])?;
+    written += write_command_sessions(&cmd_sessions, &mut cmd_buffer[written..])?;
+    written += cmd.try_marshal(&mut cmd_buffer[written..])?;
+
+    // Update the command size
+    cmd_header.size = written as u32;
+    let _ = cmd_header.try_marshal(&mut cmd_buffer)?;
+
+    let mut resp_buffer = [0u8; RESP_BUFFER_SIZE];
+    tpm.transact(&cmd_buffer[..written], &mut resp_buffer)?;
+
+    let (resp_header, read) = read_response_header(&resp_buffer)?;
+    let resp_size = resp_header.size as usize;
+    if resp_size > resp_buffer.len() {
+        return TpmResult::Err(TssTcsError::OutOfMemory.into());
+    }
+    let mut unmarsh = UnmarshalBuf::new(&resp_buffer[read..resp_size]);
+    let resp_handles = CmdT::RespHandles::try_unmarshal(&mut unmarsh)?;
+    if resp_header.tag == TPM2ST::Sessions {
+        let _param_size = u32::try_unmarshal(&mut unmarsh)?;
+    }
+    let resp = CmdT::RespT::try_unmarshal(&mut unmarsh)?;
+    read_response_sessions(&cmd_sessions, &mut unmarsh)?;
+
+    if !unmarsh.is_empty() {
+        return TpmResult::Err(TssTcsError::TpmUnexpected.into());
+    }
+    Ok((resp, resp_handles))
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::sessions::{PasswordSession, Session};
+
     use super::*;
+    use tpm2_rs_base::constants::TPM2Handle;
     use tpm2_rs_base::errors::TpmRcError;
+    use tpm2_rs_base::TpmaSession;
 
     // A Tpm that just returns a general failure error.
     struct ErrorTpm();
@@ -96,15 +161,18 @@ mod tests {
     #[derive(Marshal)]
     #[repr(C)]
     // Larger than the maximum size.
-    struct HugeFakeCommand([u8; MAX_CMD_SIZE + 1]);
+    struct HugeFakeCommand([u8; CMD_BUFFER_SIZE]);
     impl TpmCommand for HugeFakeCommand {
         const CMD_CODE: TPM2CC = TPM2CC::NVUndefineSpaceSpecial;
+        type Handles = ();
         type RespT = u8;
+        type RespHandles = ();
     }
+
     #[test]
     fn test_command_too_large() {
         let mut fake_tpm = ErrorTpm();
-        let too_large = HugeFakeCommand([0; MAX_CMD_SIZE + 1]);
+        let too_large = HugeFakeCommand([0; CMD_BUFFER_SIZE]);
         assert_eq!(
             run_command(&too_large, &mut fake_tpm),
             Err(TpmRcError::Memory.into())
@@ -116,7 +184,9 @@ mod tests {
     struct TestCommand(u32);
     impl TpmCommand for TestCommand {
         const CMD_CODE: TPM2CC = TPM2CC::NVUndefineSpaceSpecial;
+        type Handles = ();
         type RespT = u32;
+        type RespHandles = ();
     }
 
     #[test]
@@ -142,13 +212,16 @@ mod tests {
             self.rxed_header = Some(CmdHeader::try_unmarshal(&mut buf)?);
             let rxed_value = u32::try_unmarshal(&mut buf)?;
 
-            let tx_header = RespHeader {
+            let mut tx_header = RespHeader {
                 tag: TPM2ST::NoSessions,
-                size: (RespHeader::wire_size() + size_of::<u32>()) as u32,
+                size: 0,
                 rc: 0,
             };
-            let written = tx_header.try_marshal(response)?;
-            rxed_value.try_marshal(&mut response[written..])?;
+            let mut written = tx_header.try_marshal(response)?;
+            written += rxed_value.try_marshal(&mut response[written..])?;
+            tx_header.size = written as u32;
+            // Update the size.
+            tx_header.try_marshal(response)?;
             Ok(())
         }
     }
@@ -162,10 +235,6 @@ mod tests {
         let cmd = TestCommand(56789);
         let result = run_command(&cmd, &mut fake_tpm);
         assert_eq!(fake_tpm.rxed_header.unwrap().code, TestCommand::CMD_CODE);
-        assert_eq!(
-            fake_tpm.rxed_bytes,
-            CmdHeader::wire_size() + size_of::<u32>()
-        );
         assert_eq!(result.unwrap(), cmd.0);
     }
 
@@ -190,6 +259,100 @@ mod tests {
         assert_eq!(
             run_command(&cmd, &mut fake_tpm),
             Err(TssTcsError::OutOfMemory.into())
+        );
+    }
+
+    pub struct FakeTpm {
+        len: usize,
+        response: [u8; RESP_BUFFER_SIZE],
+        header: RespHeader,
+    }
+    impl Default for FakeTpm {
+        fn default() -> Self {
+            FakeTpm {
+                len: 0,
+                response: [0; RESP_BUFFER_SIZE],
+                header: RespHeader {
+                    tag: TPM2ST::NoSessions,
+                    size: 0,
+                    rc: 0,
+                },
+            }
+        }
+    }
+    impl Tpm for FakeTpm {
+        fn transact(&mut self, _: &[u8], response: &mut [u8]) -> TpmResult<()> {
+            let off = self.header.try_marshal(response)?;
+            let length = off + self.len;
+            if self.len > response.len() {
+                return Err(TpmRcError::Size.into());
+            }
+            response[off..length].copy_from_slice(&self.response[..self.len]);
+            self.header.size = length as u32;
+            self.header.try_marshal(response)?;
+            Ok(())
+        }
+    }
+    impl FakeTpm {
+        fn add_to_response<M: Marshalable>(&mut self, val: &M) {
+            self.len += val.try_marshal(&mut self.response[self.len..]).unwrap()
+        }
+    }
+
+    #[derive(Marshal)]
+    #[repr(C)]
+    struct TestHandlesCommand();
+    impl TpmCommand for TestHandlesCommand {
+        const CMD_CODE: TPM2CC = TPM2CC::NVUndefineSpaceSpecial;
+        type Handles = TPM2Handle;
+        type RespT = ();
+        type RespHandles = TPM2Handle;
+    }
+
+    #[test]
+    fn test_response_missing_handles() {
+        let mut fake_tpm = FakeTpm::default();
+        let cmd = TestHandlesCommand();
+        assert_eq!(
+            run_command(&cmd, &mut fake_tpm),
+            Err(TpmRcError::Memory.into())
+        );
+    }
+
+    #[test]
+    fn test_response_missing_sessions() {
+        let mut fake_tpm = FakeTpm::default();
+        // Respond with the single response handle.
+        fake_tpm.add_to_response(&TPM2Handle(77));
+
+        let cmd = TestHandlesCommand();
+        let mut sessions = CmdSessions::default();
+        let mut session = PasswordSession::default();
+        sessions.push(&mut session);
+        assert_eq!(
+            run_command_with_handles(&cmd, TPM2Handle::RSPW, sessions, &mut fake_tpm),
+            Err(TpmRcError::Memory.into())
+        );
+    }
+
+    #[test]
+    fn test_response_session_fails_validation() {
+        let mut fake_tpm = FakeTpm::default();
+        // Respond with the single response handle, and an invalid password auth.
+        fake_tpm.add_to_response(&TPM2Handle(77));
+        let mut invalid_auth = TpmsAuthResponse::default();
+        invalid_auth.session_attributes = TpmaSession(0xf);
+        let validation_failure = PasswordSession::default().validate_auth_response(&invalid_auth);
+        assert!(validation_failure.is_err());
+        fake_tpm.add_to_response(&invalid_auth);
+
+        let cmd = TestHandlesCommand();
+        let mut sessions = CmdSessions::default();
+        let mut session = PasswordSession::default();
+        sessions.push(&mut session);
+        assert_eq!(
+            run_command_with_handles(&cmd, TPM2Handle::RSPW, sessions, &mut fake_tpm),
+            Err(validation_failure.err().unwrap())
         );
     }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -17,7 +17,7 @@ pub trait Tpm {
     fn transact(&mut self, command: &[u8], response: &mut [u8]) -> TpmResult<()>;
 }
 
-pub fn get_capability<T: Tpm + ?Sized>(
+pub fn get_capability<T: Tpm>(
     tpm: &mut T,
     command: &GetCapabilityCmd,
 ) -> TpmResult<GetCapabilityResp> {
@@ -54,7 +54,7 @@ pub struct RespHeader {
 pub fn run_command<CmdT, T>(cmd: &CmdT, tpm: &mut T) -> TpmResult<CmdT::RespT>
 where
     CmdT: TpmCommand,
-    T: Tpm + ?Sized,
+    T: Tpm,
 {
     Ok(run_command_with_handles(cmd, CmdT::Handles::default(), CmdSessions::default(), tpm)?.0)
 }
@@ -105,7 +105,7 @@ pub fn run_command_with_handles<CmdT, T>(
 ) -> TpmResult<(CmdT::RespT, CmdT::RespHandles)>
 where
     CmdT: TpmCommand,
-    T: Tpm + ?Sized,
+    T: Tpm,
 {
     let mut cmd_buffer = [0u8; CMD_BUFFER_SIZE];
     let mut cmd_header = CmdHeader::new(cmd_sessions.is_empty(), CmdT::CMD_CODE);

--- a/client/src/sessions.rs
+++ b/client/src/sessions.rs
@@ -1,0 +1,62 @@
+use arrayvec::ArrayVec;
+use tpm2_rs_base::errors::{TpmResult, TssTcsError};
+use tpm2_rs_base::{
+    Tpm2bAuth, Tpm2bNonce, Tpm2bSimple, TpmaSession, TpmiShAuthSession, TpmsAuthCommand,
+    TpmsAuthResponse,
+};
+
+/// Trait for types representing TPM sessions.
+pub trait Session {
+    /// Computes the authorization HMAC for this session.
+    fn get_auth_command(&self) -> TpmsAuthCommand;
+    /// Validates the authorization response for this session.
+    fn validate_auth_response(&self, auth: &TpmsAuthResponse) -> TpmResult<()>;
+}
+
+/// Container for sessions associated with a TPM command. A command can have up to three sessions.
+pub type CmdSessions<'a> = ArrayVec<&'a mut dyn Session, 3>;
+
+/// A password session.
+#[derive(Debug, PartialEq, Default)]
+pub struct PasswordSession {
+    auth: Tpm2bAuth,
+}
+
+impl Session for PasswordSession {
+    fn get_auth_command(&self) -> TpmsAuthCommand {
+        TpmsAuthCommand {
+            session_handle: TpmiShAuthSession::RS_PW,
+            nonce: Tpm2bNonce::default(),
+            session_attributes: TpmaSession(0),
+            hmac: self.auth,
+        }
+    }
+    fn validate_auth_response(&self, auth: &TpmsAuthResponse) -> TpmResult<()> {
+        // Password response auth should have empty nonce/hmac and ContinueSession attribute.
+        if auth.nonce.get_size() != 0
+            || auth.session_attributes.0 != 0x1
+            || auth.hmac.get_size() != 0
+        {
+            Err(TssTcsError::BadParameter.into())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tpm2_rs_base::Tpm2bSimple;
+
+    use super::*;
+
+    #[test]
+    fn test_password_get_auth_command() {
+        let auth = Tpm2bAuth::from_bytes("hello".as_bytes()).unwrap();
+        let session = PasswordSession { auth };
+
+        let tpm_auth = session.get_auth_command();
+        assert_eq!(tpm_auth.session_handle, TpmiShAuthSession::RS_PW);
+        assert_eq!(auth, tpm_auth.hmac);
+    }
+}

--- a/marshal/src/lib.rs
+++ b/marshal/src/lib.rs
@@ -51,6 +51,14 @@ impl<'a> UnmarshalBuf<'a> {
             Some(yours)
         }
     }
+
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
 }
 
 // Helper to define Marshalable for primitive types with {to,from}_be_bytes methods.


### PR DESCRIPTION
This starts to add support for sessions and handles to the client. It
* defines some types/consts needed
* defines the session trait and adds basic operations for a password session
* adds routines for using the simplest sessions/handles for commands
This is the bare minimum to support a password session and thus does not support parameter encryption.

I've left using these with a command to a followup just to keep size down.