### PR TITLE
FIX #55: Delegate size calculation for TPMU* to rust compiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "marshal",
     "marshal/derive",
     "service",
+    "unionify"
 ]
 
 [workspace.dependencies]
@@ -18,9 +19,9 @@ hex-literal = { version = "0.4.1" }
 open-enum = "0.4.1"
 proc-macro2 = "1"
 quote = "1"
-syn = "2"
+syn = {version = "2", features = ["full"]}
 zerocopy = { version = "0.7.0", features = ["derive"] }
-
+trybuild = { version = "1.0.89", features = ["diff"] }
 # Common workspace crates
 tpm2-rs-base = { path = "base" }
 tpm2-rs-client = { path = "client" }
@@ -29,3 +30,4 @@ tpm2-rs-features-client = { path = "client/feature" }
 tpm2-rs-marshal = { path = "marshal" }
 tpm2-rs-marshal-derive = { path = "marshal/derive" }
 tpm2-rs-service = { path = "service" }
+unionify = { path = "unionify" }

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -8,7 +8,7 @@ tpm2-rs-errors = { workspace = true }
 tpm2-rs-marshal = { workspace = true }
 open-enum = { workspace = true }
 bitflags = { workspace = true }
-
+unionify = { workspace = true }
 [dev-dependencies]
 # Include debug implemenation for unit tests
 tpm2-rs-errors = { workspace = true, features = ["debug"] }

--- a/unionify/Cargo.toml
+++ b/unionify/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "unionify"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# unionify-derive is not part of workspace because we do not want anyone
+# to accidentally import it
+unionify-derive = { path = "./unionify-derive/" }
+
+[dev-dependencies]
+trybuild = { workspace = true }

--- a/unionify/src/lib.rs
+++ b/unionify/src/lib.rs
@@ -1,0 +1,35 @@
+//! [UnionSize] is a derivable trait that calculates the size of union part
+//! in a tagged or untagged enum.
+//!
+//! # Example
+//! ```rust
+//! use unionify::UnionSize;
+//! #[derive(UnionSize)]
+//! enum Foo {
+//!     V1(u8),
+//!     V2([u32; 128]),
+//!     V3{
+//!         buffer: [u8;32]
+//!     },
+//!     V4
+//! }
+//! assert_eq!(Foo::UNION_SIZE, 128*32/8);
+//! ```
+
+pub use unionify_derive::UnionSize;
+
+pub trait UnionSize {
+    /// The size (in bytes) of union equivalent to the algebraic enum in question.
+    const UNION_SIZE: usize;
+}
+
+#[cfg(test)]
+
+mod test {
+    #[test]
+    fn test_unionify() {
+        let t = trybuild::TestCases::new();
+        t.pass("tests/pass/*.rs");
+        t.compile_fail("tests/fail/*.rs")
+    }
+}

--- a/unionify/src/lib.rs
+++ b/unionify/src/lib.rs
@@ -1,5 +1,5 @@
-//! [UnionSize] is a derivable trait that calculates the size of union part
-//! in a tagged or untagged enum.
+//! [UnionSize] is a derivable trait that calculates the size of
+//! `repr(C)` union part in a tagged or untagged enum.
 //!
 //! # Example
 //! ```rust
@@ -19,7 +19,7 @@
 pub use unionify_derive::UnionSize;
 
 pub trait UnionSize {
-    /// The size (in bytes) of union equivalent to the algebraic enum in question.
+    /// The size (in bytes) of `repr(C)`-union-equivalent to the algebraic enum in question.
     const UNION_SIZE: usize;
 }
 

--- a/unionify/tests/fail/const_generics.rs
+++ b/unionify/tests/fail/const_generics.rs
@@ -1,0 +1,10 @@
+use unionify::UnionSize;
+
+///TODO support me
+#[derive(UnionSize)]
+pub enum Foo<const N: usize> {
+    A([u32; N]),
+    B(u64),
+}
+
+fn main() {}

--- a/unionify/tests/fail/const_generics.stderr
+++ b/unionify/tests/fail/const_generics.stderr
@@ -1,0 +1,5 @@
+error: UnionSize is only supported on enums without generics
+ --> tests/fail/const_generics.rs:5:13
+  |
+5 | pub enum Foo<const N: usize> {
+  |             ^

--- a/unionify/tests/fail/error_aggregation.rs
+++ b/unionify/tests/fail/error_aggregation.rs
@@ -1,0 +1,10 @@
+use unionify::UnionSize;
+
+#[derive(UnionSize)]
+pub enum Foo {
+    A { a1: u8, a2: u8 },
+    B { b1: u64, b2: u64 },
+    C { c1: u8, c2: u16 },
+}
+
+fn main() {}

--- a/unionify/tests/fail/error_aggregation.stderr
+++ b/unionify/tests/fail/error_aggregation.stderr
@@ -1,0 +1,17 @@
+error: UnionSize is not derivable for enum variants containing more than one field
+ --> tests/fail/error_aggregation.rs:5:7
+  |
+5 |     A { a1: u8, a2: u8 },
+  |       ^^^^^^^^^^^^^^^^^^
+
+error: UnionSize is not derivable for enum variants containing more than one field
+ --> tests/fail/error_aggregation.rs:6:7
+  |
+6 |     B { b1: u64, b2: u64 },
+  |       ^^^^^^^^^^^^^^^^^^^^
+
+error: UnionSize is not derivable for enum variants containing more than one field
+ --> tests/fail/error_aggregation.rs:7:7
+  |
+7 |     C { c1: u8, c2: u16 },
+  |       ^^^^^^^^^^^^^^^^^^^

--- a/unionify/tests/fail/generics.rs
+++ b/unionify/tests/fail/generics.rs
@@ -1,0 +1,9 @@
+use unionify::UnionSize;
+
+#[derive(UnionSize)]
+pub enum Foo<T> {
+    A(T),
+    B(u64),
+}
+
+fn main() {}

--- a/unionify/tests/fail/generics.stderr
+++ b/unionify/tests/fail/generics.stderr
@@ -1,0 +1,5 @@
+error: UnionSize is only supported on enums without generics
+ --> tests/fail/generics.rs:4:13
+  |
+4 | pub enum Foo<T> {
+  |             ^

--- a/unionify/tests/fail/multi_named_variants.rs
+++ b/unionify/tests/fail/multi_named_variants.rs
@@ -1,0 +1,9 @@
+use unionify::UnionSize;
+
+#[derive(UnionSize)]
+pub enum Foo {
+    A { x: u8, y: u8 },
+    B(u64),
+}
+
+fn main() {}

--- a/unionify/tests/fail/multi_named_variants.stderr
+++ b/unionify/tests/fail/multi_named_variants.stderr
@@ -1,0 +1,5 @@
+error: UnionSize is not derivable for enum variants containing more than one field
+ --> tests/fail/multi_named_variants.rs:5:7
+  |
+5 |     A { x: u8, y: u8 },
+  |       ^^^^^^^^^^^^^^^^

--- a/unionify/tests/fail/multi_unnamed_variants.rs
+++ b/unionify/tests/fail/multi_unnamed_variants.rs
@@ -1,0 +1,9 @@
+use unionify::UnionSize;
+
+#[derive(UnionSize)]
+pub enum Foo {
+    A(u8, u8),
+    B(u64),
+}
+
+fn main() {}

--- a/unionify/tests/fail/multi_unnamed_variants.stderr
+++ b/unionify/tests/fail/multi_unnamed_variants.stderr
@@ -1,0 +1,5 @@
+error: UnionSize is not derivable for enum variants containing more than one field
+ --> tests/fail/multi_unnamed_variants.rs:5:6
+  |
+5 |     A(u8, u8),
+  |      ^^^^^^^^

--- a/unionify/tests/fail/zero_sized_union.rs
+++ b/unionify/tests/fail/zero_sized_union.rs
@@ -1,0 +1,9 @@
+use unionify::UnionSize;
+
+#[derive(UnionSize)]
+pub enum Foo {
+    A,
+    B,
+}
+
+fn main() {}

--- a/unionify/tests/fail/zero_sized_union.stderr
+++ b/unionify/tests/fail/zero_sized_union.stderr
@@ -1,0 +1,7 @@
+error: unions cannot have zero fields
+ --> tests/fail/zero_sized_union.rs:3:10
+  |
+3 | #[derive(UnionSize)]
+  |          ^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `UnionSize` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/unionify/tests/pass/empty_variant.rs
+++ b/unionify/tests/pass/empty_variant.rs
@@ -1,0 +1,9 @@
+use unionify::UnionSize;
+
+#[derive(UnionSize)]
+pub enum Foo {
+    A { a: u8 },
+    B,
+}
+
+fn main() {}

--- a/unionify/tests/pass/mixed_variants.rs
+++ b/unionify/tests/pass/mixed_variants.rs
@@ -1,0 +1,9 @@
+use unionify::UnionSize;
+
+#[derive(UnionSize)]
+pub enum Foo {
+    A { a: u8 },
+    B(u64),
+}
+
+fn main() {}

--- a/unionify/tests/pass/named_variants.rs
+++ b/unionify/tests/pass/named_variants.rs
@@ -1,0 +1,9 @@
+use unionify::UnionSize;
+
+#[derive(UnionSize)]
+pub enum Foo {
+    A { a: u8 },
+    B { b: u64 },
+}
+
+fn main() {}

--- a/unionify/tests/pass/partially_tagged_variants.rs
+++ b/unionify/tests/pass/partially_tagged_variants.rs
@@ -1,0 +1,10 @@
+use unionify::UnionSize;
+
+#[derive(UnionSize)]
+#[repr(u16)]
+pub enum Foo {
+    A(u8) = 10,
+    B(u64),
+}
+
+fn main() {}

--- a/unionify/tests/pass/unnamed_variants.rs
+++ b/unionify/tests/pass/unnamed_variants.rs
@@ -1,0 +1,9 @@
+use unionify::UnionSize;
+
+#[derive(UnionSize)]
+pub enum Foo {
+    A(u8),
+    B(u64),
+}
+
+fn main() {}

--- a/unionify/unionify-derive/Cargo.toml
+++ b/unionify/unionify-derive/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "unionify-derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
+

--- a/unionify/unionify-derive/src/lib.rs
+++ b/unionify/unionify-derive/src/lib.rs
@@ -1,0 +1,130 @@
+#![forbid(unsafe_code)]
+
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{
+    parse_macro_input, punctuated::Punctuated, spanned::Spanned, Error, Field, Fields, Ident,
+    ItemEnum, Result, Token, Type, Variant, Visibility,
+};
+
+fn enum_fields_to_union_type(fields: Fields) -> Result<Option<Type>> {
+    let fields_span = fields.span();
+    let field_items = match fields {
+        syn::Fields::Named(f) => f.named,
+        syn::Fields::Unnamed(f) => f.unnamed,
+        syn::Fields::Unit => {
+            return Ok(None);
+        }
+    };
+    if field_items.len() != 1 {
+        // TODO maybe we should support that later.
+        // The idea is to create a struct and put everything there,
+        // but this struct will only be used by the union we build.
+        return Err(Error::new(
+            fields_span,
+            "UnionSize is not derivable for enum variants containing more than one field",
+        ));
+    }
+    // unwrap is safe here because we previusly checked that length of the
+    // iterator is exactly 1
+    let item = field_items.into_iter().next().unwrap();
+    Ok(Some(item.ty))
+}
+
+/// converts enum variant to union field, we ignore all attributes there
+/// we also ignore the discriminant, the general assumption is this is a
+/// field in tagged enum, but if there is no tag, well it cannot be helped
+/// but that will not stop us from gnerating equivalent union
+/// we may return an error if enum_to_fields failed to do the conversion.
+fn enum_variant_to_union_field(v: Variant) -> Result<Option<Field>> {
+    let variant_ty = match enum_fields_to_union_type(v.fields)? {
+        Some(ty) => ty,
+        None => {
+            return Ok(None);
+        }
+    };
+    let field = Field {
+        attrs: Vec::default(),
+        vis: Visibility::Inherited,
+        mutability: syn::FieldMutability::None,
+        ident: Some(v.ident),
+        colon_token: Some(Default::default()),
+        ty: variant_ty,
+    };
+    Ok(Some(field))
+}
+
+/// combine an iterator of errors to single error.
+/// Returns `Ok(())` if there is no errors to combine, other wise return `Err(t)` where t is the aggregate of all
+/// errors in the iterator
+fn errors_to_error<I: Iterator<Item = Error>>(mut errors: I) -> Result<()> {
+    let Some(mut e1) = errors.next() else {
+        return Ok(());
+    };
+    for e in errors {
+        e1.combine(e);
+    }
+    Err(e1)
+}
+
+/// converts tagged enum to union
+/// Returns error in on of those cases:
+/// - If the enum is parametrized by any kind of generics
+/// - The enum variant has more than one field
+fn tagged_enum_to_union(tagged_enum: ItemEnum, union_name: &Ident) -> Result<TokenStream> {
+    // so if there is any kind of generics, we product an error. Later we can handle
+    // them if the need arises
+    if !tagged_enum.generics.params.is_empty() {
+        return Err(Error::new(
+            tagged_enum.generics.span(),
+            "UnionSize is only supported on enums without generics",
+        ));
+    }
+    let (union_fields_vec, errors): (Vec<_>, Vec<_>) = tagged_enum
+        .variants
+        .into_iter()
+        .map(enum_variant_to_union_field)
+        .partition(Result::is_ok);
+    errors_to_error(errors.into_iter().map(|e| e.err().unwrap()))?;
+    let union_fields: Punctuated<Field, Token![,]> = union_fields_vec
+        .into_iter()
+        .filter_map(|t| t.unwrap())
+        .collect();
+    // we generated C like union, and we don't want the compiler to complain
+    // about anything of the generated code
+    let untagged_union = quote!(
+        #[allow(warnings, unused)]
+        #[repr(C)]
+        union #union_name {
+            #union_fields
+        }
+    );
+    Ok(untagged_union)
+}
+
+/// build anonymous module containing the generated union, and trait implementation of
+/// `unionify::UnionSize`
+fn construct_module(tagged_enum: ItemEnum) -> Result<TokenStream> {
+    let enum_ident = tagged_enum.ident.clone();
+    let union_name = Ident::new("InnerUnion", Span::call_site());
+    let union = tagged_enum_to_union(tagged_enum, &union_name)?;
+    let module = quote! (
+        const _ : () = {
+            #union
+            impl unionify::UnionSize for #enum_ident {
+                const UNION_SIZE : usize = core::mem::size_of::<#union_name>();
+            }
+        };
+    );
+    Ok(module)
+}
+
+///top level macro
+#[proc_macro_derive(UnionSize)]
+pub fn derive_union_size(items: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let tagged_enum = parse_macro_input!(items as ItemEnum);
+    match construct_module(tagged_enum) {
+        Err(e) => e.to_compile_error().into(),
+        Ok(s) => s.into(),
+    }
+}


### PR DESCRIPTION
Recreating the #59  since it was closed after making tpm-rs public