### PR TITLE
Add CreatePrimary command support.

### DIFF
--- a/base/src/commands.rs
+++ b/base/src/commands.rs
@@ -1,5 +1,8 @@
 use crate::constants::{TPM2Cap, TPM2CC, TPM2PT, TPM2SU};
-use crate::{Marshal, Marshalable, UnmarshalBuf};
+use crate::{
+    Marshal, Marshalable, TPM2Handle, Tpm2bCreationData, Tpm2bData, Tpm2bDigest, Tpm2bName,
+    Tpm2bPublic, Tpm2bSensitiveCreate, TpmiRhHierarchy, TpmtTkCreation, UnmarshalBuf,
+};
 use crate::{TpmiYesNo, TpmlDigest, TpmlPcrSelection, TpmsCapabilityData};
 
 /// Trait for a TPM command transaction.
@@ -65,4 +68,29 @@ pub struct PcrReadResp {
     pcr_update_counter: u32,
     pcr_selection_out: TpmlPcrSelection,
     pcr_values: TpmlDigest,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshal)]
+pub struct CreatePrimaryCmd {
+    pub in_sensitive: Tpm2bSensitiveCreate,
+    pub in_public: Tpm2bPublic,
+    pub outside_info: Tpm2bData,
+    pub creation_pcr: TpmlPcrSelection,
+}
+impl TpmCommand for CreatePrimaryCmd {
+    const CMD_CODE: TPM2CC = TPM2CC::CreatePrimary;
+    type Handles = TpmiRhHierarchy;
+    type RespT = CreatePrimaryResp;
+    type RespHandles = TPM2Handle;
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshal)]
+pub struct CreatePrimaryResp {
+    pub out_public: Tpm2bPublic,
+    pub creation_data: Tpm2bCreationData,
+    pub creation_hash: Tpm2bDigest,
+    pub creation_ticket: TpmtTkCreation,
+    pub name: Tpm2bName,
 }

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -294,6 +294,18 @@ impl TryFrom<u32> for TpmiRhNvIndex {
     }
 }
 
+/// TpmiRhHierarchy represents a hierarchy selector handle (TPMI_RH_HIERARCHY).
+/// See definition in Part 2: Structures, section 9.13.
+#[open_enum]
+#[repr(u32)]
+#[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
+#[derive(Copy, Clone, PartialEq, Default, Marshal)]
+pub enum TpmiRhHierarchy {
+    Owner = TPM2Handle::RHOwner.0,
+    Platform = TPM2Handle::RHPlatform.0,
+    Endorsement = TPM2Handle::RHEndorsement.0,
+}
+
 /// TpmiShAuthSessions represents handles referring to an authorization session (TPMI_SH_AUTH_SESSION).
 /// See definition in Part 2: Structures, section 9.8.
 #[repr(transparent)]
@@ -322,6 +334,11 @@ impl TpmiShAuthSession {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmiEccCurve(TPM2ECCCurve);
+impl TpmiEccCurve {
+    pub fn new(curve: TPM2ECCCurve) -> TpmiEccCurve {
+        TpmiEccCurve(curve)
+    }
+}
 
 /// TpmiYesNo is used in place of a boolean.
 /// See TPMI_YES_NO definition in Part 2: Structures, section 9.2.
@@ -575,6 +592,14 @@ impl TpmuName {
     pub const fn union_size() -> usize {
         size_of::<TpmuName>() - align_of::<TpmuName>() - size_of::<u16>()
     }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshal)]
+pub struct TpmtTkCreation {
+    tag: TPM2ST,
+    hierarchy: TpmiRhHierarchy,
+    digest: Tpm2bDigest,
 }
 
 #[repr(C)]
@@ -865,7 +890,7 @@ pub struct Tpm2bEccParameter {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Marshal)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Marshal)]
 pub struct TpmsEccPoint {
     pub x: Tpm2bEccParameter,
     pub y: Tpm2bEccParameter,

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,3 +14,4 @@ tpm2-rs-marshal = { workspace = true }
 [dev-dependencies]
 zerocopy = { workspace = true }
 tpm2-rs-features-client = { workspace = true }
+tpm2-rs-errors = { workspace = true, features = ["debug"] }

--- a/client/feature/Cargo.toml
+++ b/client/feature/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 tpm2-rs-base = { path = "../../base" }
 tpm2-rs-client = { path = "../" }
+
+[dev-dependencies]
+tpm2-rs-errors = { workspace = true, features = ["debug"] }

--- a/client/feature/src/lib.rs
+++ b/client/feature/src/lib.rs
@@ -1,33 +1,68 @@
 #![forbid(unsafe_code)]
-use tpm2_rs_base::commands::*;
-use tpm2_rs_base::constants::{TPM2Cap, TPM2PT};
+use tpm2_rs_base::constants::{TPM2Cap, TPM2Handle, TPM2PT};
 use tpm2_rs_base::errors::{TpmRcError, TpmResult};
 use tpm2_rs_base::TpmsCapabilityData;
+use tpm2_rs_base::{
+    commands::*, Tpm2bAuth, Tpm2bData, Tpm2bPublic, Tpm2bSensitiveCreate, Tpm2bSensitiveData,
+    Tpm2bSimple, Tpm2bStruct, TpmiRhHierarchy, TpmlPcrSelection, TpmsSensitiveCreate, TpmtPublic,
+};
 use tpm2_rs_client::*;
 
 // # Feature Client
 //
 // The feature client provides higher-level abstractions than the base TPM client.
 
-// Gets the TPM manufacturer ID.
-pub fn get_manufacturer_id<T>(tpm: &mut T) -> TpmResult<u32>
-where
-    T: Tpm,
-{
-    const CMD: GetCapabilityCmd = GetCapabilityCmd {
-        capability: TPM2Cap::TPMProperties,
-        property: TPM2PT::Manufacturer,
-        property_count: 1,
-    };
-    let resp = run_command(&CMD, tpm)?;
-    if let TpmsCapabilityData::TpmProperties(prop) = resp.capability_data {
-        if prop.count() == 1 {
-            Ok(prop.tpm_property()[0].value)
+pub struct TpmClient<T: Tpm + ?Sized> {
+    pub tpm: T,
+}
+
+impl<T: Tpm> TpmClient<T> {
+    /// Gets the TPM manufacturer ID.
+    pub fn get_manufacturer_id(&mut self) -> TpmResult<u32> {
+        const CMD: GetCapabilityCmd = GetCapabilityCmd {
+            capability: TPM2Cap::TPMProperties,
+            property: TPM2PT::Manufacturer,
+            property_count: 1,
+        };
+        let resp = get_capability(&mut self.tpm, &CMD)?;
+        if let TpmsCapabilityData::TpmProperties(prop) = resp.capability_data {
+            if prop.count() == 1 {
+                Ok(prop.tpm_property()[0].value)
+            } else {
+                Err(TpmRcError::Size.into())
+            }
         } else {
-            Err(TpmRcError::Size.into())
+            Err(TpmRcError::Selector.into())
         }
-    } else {
-        Err(TpmRcError::Selector.into())
+    }
+
+    /// Creates a tpm-held primary key with the specified template and hierarchy.
+    pub fn create_primary(
+        &mut self,
+        hierarchy: TpmiRhHierarchy,
+        public: TpmtPublic,
+        nonce: Option<&[u8]>,
+    ) -> TpmResult<TPM2Handle> {
+        let outside_info = if let Some(nonce) = nonce {
+            Tpm2bData::from_bytes(nonce)?
+        } else {
+            Tpm2bData::default()
+        };
+        let in_sensitive = TpmsSensitiveCreate {
+            user_auth: Tpm2bAuth::default(),
+            data: Tpm2bSensitiveData::default(),
+        };
+        let in_public = Tpm2bPublic::from_struct(&public)?;
+        let cmd = CreatePrimaryCmd {
+            in_sensitive: Tpm2bSensitiveCreate::from_struct(&in_sensitive)?,
+            in_public,
+            outside_info,
+            creation_pcr: TpmlPcrSelection::default(),
+        };
+
+        let (_, handle) = create_primary(&mut self.tpm, &cmd, hierarchy)?;
+        // TODO: (automatically) free handles
+        Ok(handle)
     }
 }
 
@@ -89,7 +124,8 @@ mod tests {
         let mut tpm = FakeTpm::default();
         tpm.len = response.try_marshal(&mut tpm.response).unwrap();
 
-        assert_eq!(get_manufacturer_id(&mut tpm), Err(TpmRcError::Size.into()));
+        let mut client = TpmClient { tpm };
+        assert_eq!(client.get_manufacturer_id(), Err(TpmRcError::Size.into()));
     }
 
     #[test]
@@ -107,8 +143,9 @@ mod tests {
         let mut tpm = FakeTpm::default();
         tpm.len = response.try_marshal(&mut tpm.response).unwrap();
 
+        let mut client = TpmClient { tpm };
         assert_eq!(
-            get_manufacturer_id(&mut tpm),
+            client.get_manufacturer_id(),
             Err(TpmRcError::Selector.into())
         );
     }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,12 +1,12 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(not(test), no_std)]
 use core::mem::size_of;
-use sessions::CmdSessions;
+use sessions::{CmdSessions, PasswordSession};
 use tpm2_rs_base::commands::*;
-use tpm2_rs_base::constants::{TPM2CC, TPM2ST};
+use tpm2_rs_base::constants::{TPM2Handle, TPM2CC, TPM2ST};
 use tpm2_rs_base::errors::{TpmError, TpmResult, TssTcsError};
 use tpm2_rs_base::marshal::{Marshal, Marshalable, UnmarshalBuf};
-use tpm2_rs_base::{TpmiStCommandTag, TpmsAuthResponse};
+use tpm2_rs_base::{TpmiRhHierarchy, TpmiStCommandTag, TpmsAuthResponse};
 
 pub const CMD_BUFFER_SIZE: usize = 4096;
 pub const RESP_BUFFER_SIZE: usize = 4096;
@@ -17,11 +17,24 @@ pub trait Tpm {
     fn transact(&mut self, command: &[u8], response: &mut [u8]) -> TpmResult<()>;
 }
 
+// These methods are syntatic sugar for calling run_command* with a specific command.
+
 pub fn get_capability<T: Tpm>(
     tpm: &mut T,
     command: &GetCapabilityCmd,
 ) -> TpmResult<GetCapabilityResp> {
     run_command(command, tpm)
+}
+
+pub fn create_primary<T: Tpm>(
+    tpm: &mut T,
+    command: &CreatePrimaryCmd,
+    primary_handle: TpmiRhHierarchy,
+) -> TpmResult<(CreatePrimaryResp, TPM2Handle)> {
+    let mut session = PasswordSession::default();
+    let mut sessions = CmdSessions::default();
+    sessions.push(&mut session);
+    run_command_with_handles(command, primary_handle, sessions, tpm)
 }
 
 #[repr(C)]


### PR DESCRIPTION
This serves as an initial use to exercise session/handle support
- Defines requisite structures
- Adds a features-level helper for invoking
- Runs against simulator for testing basic functionality