### PR TITLE
Sub-in trent-reed for esmusick as MAINTAINERS

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,7 +23,7 @@ have the authority to bind that organization to these policies.
 | bradlitterell | Microsoft | yes |
 | chrisfenner | Google | yes |
 | a-pronin | Google | yes |
-| esmusick | Google | yes |
+| trent-reed | Google | yes |
 | jettr | Google | yes |
 
 ## Attribution


### PR DESCRIPTION
Emily has moved on from Google, and Trent will be jumping in.