### PR TITLE
Rename tpm2-rs-marshal and tpm2-rs-marshal-derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ members = [
     "client",
     "client-features",
     "errors",
-    "marshal",
-    "marshal-derive",
+    "marshalable",
+    "marshalable-derive",
     "service",
     "unionify",
     "unionify-derive"
@@ -29,8 +29,8 @@ tpm2-rs-base = { path = "base" }
 tpm2-rs-client = { path = "client" }
 tpm2-rs-client-features = { path = "client-features" }
 tpm2-rs-errors = { path = "errors" }
-tpm2-rs-marshal = { path = "marshal" }
-tpm2-rs-marshal-derive = { path = "marshal-derive" }
+tpm2-rs-marshalable = { path = "marshalable" }
+tpm2-rs-marshalable-derive = { path = "marshalable-derive" }
 tpm2-rs-service = { path = "service" }
 tpm2-rs-unionify = { path = "unionify" }
 tpm2-rs-unionify-derive = { path = "unionify-derive" }

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 bitflags = { workspace = true }
 open-enum = { workspace = true }
 tpm2-rs-errors = { workspace = true }
-tpm2-rs-marshal = { workspace = true }
+tpm2-rs-marshalable = { workspace = true }
 tpm2-rs-unionify = { workspace = true }
 
 [dev-dependencies]

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -8,7 +8,7 @@ use core::cmp::min;
 use core::mem::size_of;
 use open_enum::open_enum;
 pub use tpm2_rs_errors as errors;
-pub use tpm2_rs_marshal as marshal;
+pub use tpm2_rs_marshalable as marshal;
 use tpm2_rs_unionify::UnionSize;
 
 pub mod commands;

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,7 +9,7 @@ tpm-simulator-tests = []
 [dependencies]
 arrayvec = { workspace = true }
 tpm2-rs-base = { workspace = true }
-tpm2-rs-marshal = { workspace = true }
+tpm2-rs-marshalable = { workspace = true }
 
 [dev-dependencies]
 tpm2-rs-client-features = { workspace = true }

--- a/marshalable-derive/Cargo.toml
+++ b/marshalable-derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tpm2-rs-marshal-derive"
+name = "tpm2-rs-marshalable-derive"
 version = "0.1.0"
 edition = "2021"
 

--- a/marshalable-derive/src/lib.rs
+++ b/marshalable-derive/src/lib.rs
@@ -71,11 +71,11 @@ fn derive_tpm_marshal_inner(input: DeriveInput) -> Result<TokenStream> {
         #pure_impl
         // The generated impl.
         impl Marshalable for #name  {
-            fn try_unmarshal(buffer: &mut UnmarshalBuf) -> tpm2_rs_marshal::exports::errors::TpmRcResult<Self> {
+            fn try_unmarshal(buffer: &mut UnmarshalBuf) -> tpm2_rs_marshalable::exports::errors::TpmRcResult<Self> {
                 #unmarsh_text
             }
 
-            fn try_marshal(&self, buffer: &mut [u8]) -> tpm2_rs_marshal::exports::errors::TpmRcResult<usize> {
+            fn try_marshal(&self, buffer: &mut [u8]) -> tpm2_rs_marshalable::exports::errors::TpmRcResult<usize> {
                 let mut written: usize = 0;
                 #marsh_text;
                 Ok(written)
@@ -148,12 +148,12 @@ fn get_enum_impl(name: &Ident, data: &DataEnum, attrs: &[Attribute]) -> Result<T
             fn discriminant(&self) -> #prim {
                 unsafe { *<*const _>::from(self).cast::<#prim>() }
             }
-            fn try_marshal_variant(&self, buffer: &mut [u8]) -> tpm2_rs_marshal::exports::errors::TpmRcResult<usize> {
+            fn try_marshal_variant(&self, buffer: &mut [u8]) -> tpm2_rs_marshalable::exports::errors::TpmRcResult<usize> {
                 let mut written: usize = 0;
                 #marshal_text;
                 Ok(written)
             }
-            fn try_unmarshal_variant(selector: #prim, buffer: &mut UnmarshalBuf) -> tpm2_rs_marshal::exports::errors::TpmRcResult<Self> {
+            fn try_unmarshal_variant(selector: #prim, buffer: &mut UnmarshalBuf) -> tpm2_rs_marshalable::exports::errors::TpmRcResult<Self> {
                 #unmarshal_text
             }
         }

--- a/marshalable/Cargo.toml
+++ b/marshalable/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "tpm2-rs-marshal"
+name = "tpm2-rs-marshalable"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
 tpm2-rs-errors = { workspace = true }
-tpm2-rs-marshal-derive = { workspace = true }
+tpm2-rs-marshalable-derive = { workspace = true }

--- a/marshalable/src/lib.rs
+++ b/marshalable/src/lib.rs
@@ -3,7 +3,7 @@
 use core::mem::size_of;
 
 use tpm2_rs_errors::*;
-pub use tpm2_rs_marshal_derive::Marshalable;
+pub use tpm2_rs_marshalable_derive::Marshalable;
 
 /// Exports needed for macro expansion
 pub mod exports {
@@ -119,8 +119,8 @@ impl<const M: usize> Marshalable for [u8; M] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    // Provide the tpm2_rs_marshal path to root to enable derive macro to work properly
-    use crate as tpm2_rs_marshal;
+    // Provide the tpm2_rs_marshalable path to root to enable derive macro to work properly
+    use crate as tpm2_rs_marshalable;
 
     macro_rules! impl_test_scalar {
         ($T:ty, $I:expr, $V:expr) => {


### PR DESCRIPTION
A prior PR (https://github.com/tpm-rs/tpm-rs/pull/80) updated the `Marshal` proc-macro to be `Marshalable` in order to make the naming more consistent. However this creates a strange naming standard for the crate - which was originally named `tpm2-rs-marshal` and `tpm2-rs-marshal-derive`. This commit renames the crates to match with the trait and proc-macro that the crates are providing.