### PR TITLE
Add --all-targets flag to cargo clippy CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,4 +77,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-targets -- -D warnings

--- a/base/src/tests.rs
+++ b/base/src/tests.rs
@@ -185,7 +185,7 @@ fn test_impl_tpml_new() {
         .collect();
     for x in 0..TPM2_MAX_CAP_HANDLES {
         let slice = &elements.as_slice()[..x];
-        let list = TpmlHandle::new(&slice).unwrap();
+        let list = TpmlHandle::new(slice).unwrap();
         assert_eq!(list.count(), x);
         assert_eq!(list.handle(), slice);
     }
@@ -205,7 +205,7 @@ fn test_impl_tpml_default_add() {
         let slice = &elements.as_slice()[..x];
         assert_eq!(list.handle(), slice);
 
-        list.add(&elements.get(x).unwrap()).unwrap();
+        list.add(elements.get(x).unwrap()).unwrap();
         assert_eq!(list.count(), x + 1);
     }
     assert!(
@@ -291,8 +291,7 @@ fn test_marshal_tpmt_public() {
     ];
     //assert_eq!(expected.len(), marsh.unwrap());
     assert_eq!(buffer[..expected.len()], expected);
-    let unmarsh_buf = buffer.clone();
-    let mut unmarsh = TpmtPublic::try_unmarshal(&mut UnmarshalBuf::new(&unmarsh_buf));
+    let mut unmarsh = TpmtPublic::try_unmarshal(&mut UnmarshalBuf::new(&buffer));
     let bytes_example = unmarsh.unwrap();
     assert_eq!(bytes_example.object_attributes, example.object_attributes);
     let mut remarsh_buffer = [1u8; 256];
@@ -303,7 +302,7 @@ fn test_marshal_tpmt_public() {
     // Test invalid selector value.
     assert!(TPM2AlgID::SHA256.try_marshal(&mut buffer).is_ok());
     unmarsh = TpmtPublic::try_unmarshal(&mut UnmarshalBuf::new(&buffer));
-    assert_eq!(unmarsh.err(), Some(TpmRcError::Selector.into()));
+    assert_eq!(unmarsh.err(), Some(TpmRcError::Selector));
 }
 
 #[test]

--- a/client/src/tests.rs
+++ b/client/src/tests.rs
@@ -9,7 +9,7 @@ use tpm2_rs_base::TpmaSession;
 struct ErrorTpm();
 impl Tpm for ErrorTpm {
     fn transact(&mut self, _: &[u8], _: &mut [u8]) -> TpmResult<()> {
-        return Err(TssTcsError::GeneralFailure.into());
+        Err(TssTcsError::GeneralFailure.into())
     }
 }
 
@@ -195,8 +195,10 @@ fn test_response_session_fails_validation() {
     let mut fake_tpm = FakeTpm::default();
     // Respond with the single response handle, and an invalid password auth.
     fake_tpm.add_to_response(&TPM2Handle(77));
-    let mut invalid_auth = TpmsAuthResponse::default();
-    invalid_auth.session_attributes = TpmaSession(0xf);
+    let invalid_auth = TpmsAuthResponse {
+        session_attributes: TpmaSession(0xf),
+        ..Default::default()
+    };
     let validation_failure = PasswordSession::default().validate_auth_response(&invalid_auth);
     assert!(validation_failure.is_err());
     fake_tpm.add_to_response(&invalid_auth);

--- a/marshalable/src/tests.rs
+++ b/marshalable/src/tests.rs
@@ -1,3 +1,10 @@
+// TODO potential bug in clippy? we need to have unit values for testing the
+// behavior of marshaling on unit, but the I could not allow this warning for
+// HasUnitField, possibly because of span bug, clippy suggested fix is syntax
+// error possibly due to another bug, and placing the allow attribute on the
+// struct or the let binding does not make the warning go aways
+#![allow(clippy::let_unit_value)]
+
 use super::*;
 
 // Provide the tpm2_rs_marshal path to root to enable derive macro to work properly


### PR DESCRIPTION
In doing so, this patch fixes couple of clippy warnings. They all fall in one of those categories:

- unneeded `return` statement
- field assignment outside of initializer for an instance created with Default::default() (essentially doing a let binding only to modify on the next line)
- unnecessary double references
- unnecessary cloning
- unnecessary `.into()`

There is however one warning that we chose to ignore, which is defining a unit field in a structure. We ignore that warning because we are testing the behavior of marshalable on zero sized types.

It was hard to convince clippy to ignore this warning and the only way that worked was placing the `allow` module-wide.

fixes: https://github.com/tpm-rs/tpm-rs/issues/77