### PR TITLE
Rename marshal to marshalable in derive attributes

### DIFF
--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -643,7 +643,7 @@ pub struct TpmsClockInfo {
 pub struct TpmsPcrSelection {
     pub hash: TpmiAlgHash,
     pub sizeof_select: u8,
-    #[marshal(length=sizeof_select)]
+    #[marshalable(length=sizeof_select)]
     pub pcr_select: [u8; TPM2_PCR_SELECT_MAX as usize],
 }
 
@@ -651,7 +651,7 @@ pub struct TpmsPcrSelection {
 #[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
 pub struct TpmlPcrSelection {
     count: u32,
-    #[marshal(length=count)]
+    #[marshalable(length=count)]
     pcr_selections: [TpmsPcrSelection; TPM2_NUM_PCR_BANKS as usize],
 }
 
@@ -1157,7 +1157,7 @@ pub enum TpmsCapabilityData {
 #[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
 pub struct TpmlAlgProperty {
     count: u32,
-    #[marshal(length=count)]
+    #[marshalable(length=count)]
     alg_properties: [TpmsAlgProperty; TPM2_MAX_CAP_ALGS],
 }
 
@@ -1165,7 +1165,7 @@ pub struct TpmlAlgProperty {
 #[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
 pub struct TpmlHandle {
     count: u32,
-    #[marshal(length=count)]
+    #[marshalable(length=count)]
     handle: [TPM2Handle; TPM2_MAX_CAP_HANDLES],
 }
 
@@ -1173,7 +1173,7 @@ pub struct TpmlHandle {
 #[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
 pub struct TpmlCca {
     count: u32,
-    #[marshal(length=count)]
+    #[marshalable(length=count)]
     command_attributes: [TpmaCc; TPM2_MAX_CAP_CC],
 }
 
@@ -1181,7 +1181,7 @@ pub struct TpmlCca {
 #[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
 pub struct TpmlCc {
     count: u32,
-    #[marshal(length=count)]
+    #[marshalable(length=count)]
     command_codes: [TPM2CC; TPM2_MAX_CAP_CC],
 }
 
@@ -1189,7 +1189,7 @@ pub struct TpmlCc {
 #[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
 pub struct TpmlTaggedTpmProperty {
     count: u32,
-    #[marshal(length=count)]
+    #[marshalable(length=count)]
     tpm_property: [TpmsTaggedProperty; TPM2_MAX_TPM_PROPERTIES],
 }
 
@@ -1197,7 +1197,7 @@ pub struct TpmlTaggedTpmProperty {
 #[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
 pub struct TpmlTaggedPcrProperty {
     count: u32,
-    #[marshal(length=count)]
+    #[marshalable(length=count)]
     pcr_property: [TpmsTaggedPcrSelect; TPM2_MAX_PCR_PROPERTIES],
 }
 
@@ -1205,7 +1205,7 @@ pub struct TpmlTaggedPcrProperty {
 #[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
 pub struct TpmlEccCurve {
     count: u32,
-    #[marshal(length=count)]
+    #[marshalable(length=count)]
     ecc_curves: [TPM2ECCCurve; TPM2_MAX_ECC_CURVES],
 }
 
@@ -1213,7 +1213,7 @@ pub struct TpmlEccCurve {
 #[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
 pub struct TpmlTaggedPolicy {
     count: u32,
-    #[marshal(length=count)]
+    #[marshalable(length=count)]
     policies: [TpmsTaggedPolicy; TPM2_MAX_TAGGED_POLICIES],
 }
 
@@ -1236,7 +1236,7 @@ pub struct TpmsTaggedProperty {
 pub struct TpmsTaggedPcrSelect {
     tag: TPM2PTPCR,
     size_of_select: u8,
-    #[marshal(length=size_of_select)]
+    #[marshalable(length=size_of_select)]
     pcr_select: [u8; TPM2_PCR_SELECT_MAX as usize],
 }
 
@@ -1251,7 +1251,7 @@ pub struct TpmsTaggedPolicy {
 #[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
 pub struct TpmlDigest {
     count: u32,
-    #[marshal(length=count)]
+    #[marshalable(length=count)]
     digests: [Tpm2bDigest; TPML_DIGEST_MAX_DIGESTS],
 }
 

--- a/marshalable-derive/src/lib.rs
+++ b/marshalable-derive/src/lib.rs
@@ -15,7 +15,7 @@ use syn::{
 /// following conditions:
 ///  - The type implements zerocopy::AsBytes and zerocopy::FromBytes
 ///  - The type is an array, the array entry type also meets these Marshal
-///    conditions, and the array field is tagged with the #[marshal(length = $length_field)]
+///    conditions, and the array field is tagged with the #[marshalable(length = $length_field)]
 ///    attribute, where $length_field is a field in the struct appearing before
 ///    the array field that can be converted to usize. In this case, the
 ///    generated code will {un}marshal first N entries in the array, where N is
@@ -25,7 +25,7 @@ use syn::{
 ///    $primitive, try_{un}marshal routines that accept an external selector, and will
 ///    {un}marshal the discriminant in BE format prior to the variant.
 
-#[proc_macro_derive(Marshalable, attributes(marshal))]
+#[proc_macro_derive(Marshalable, attributes(marshalable))]
 pub fn derive_tpm_marshal(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     match derive_tpm_marshal_inner(input) {
@@ -287,11 +287,11 @@ fn get_enum_marshal_body(struct_name: &Ident, data: &DataEnum) -> Result<TokenSt
 fn get_marshal_attribute(attrs: &[Attribute], key: &str) -> Result<Option<Path>> {
     let mut marshal_attr: Option<MetaNameValue> = None;
     for attr in attrs {
-        if attr.path().is_ident("marshal") {
+        if attr.path().is_ident("marshalable") {
             if marshal_attr.is_some() {
                 return Err(Error::new(
                     attr.span(),
-                    "Only one #[marshal(...)] is permitted for field",
+                    "Only one #[marshalable(...)] is permitted for field",
                 ));
             }
             marshal_attr = Some(attr.parse_args()?);

--- a/marshalable/src/tests.rs
+++ b/marshalable/src/tests.rs
@@ -147,7 +147,7 @@ fn test_derive_bounds() {
 struct HasArray {
     count: u8,
     other: u32,
-    #[marshal(length=count)]
+    #[marshalable(length=count)]
     array: [u8; 128],
 }
 


### PR DESCRIPTION
Following the initiative in #80 and #81. This patch renames the derive attributes from marshal to mashalable,
and propagates the change to error messages and docs.