### PR TITLE
Add a new trait: MarshalableVariant

### DIFF
--- a/marshalable/src/tests.rs
+++ b/marshalable/src/tests.rs
@@ -236,3 +236,27 @@ fn test_derive_unit_struct() {
     let unmarshal = HasUnitField::try_unmarshal(&mut UnmarshalBuf::new(&buffer));
     assert_eq!(value, unmarshal.unwrap())
 }
+
+#[repr(C, u8)]
+#[derive(Copy, Clone, Debug, Marshalable, PartialEq)]
+enum EnumWithVariantData {
+    A(u8) = 1,
+    B(u8) = 2,
+    C(u64) = 3,
+}
+
+#[test]
+fn test_derive_enum() -> Result<(), TpmRcError> {
+    let original = EnumWithVariantData::B(0x42);
+    assert_eq!(original.discriminant(), 2);
+
+    let mut buffer = [0u8; size_of::<u8>()];
+    assert_eq!(original.try_marshal_variant(&mut buffer), Ok(1));
+    assert_eq!(&buffer, &[0x42]);
+    let unmarshaled =
+        EnumWithVariantData::try_unmarshal_variant(2, &mut UnmarshalBuf::new(&buffer))?;
+    assert_eq!(unmarshaled.discriminant(), 2);
+    assert_eq!(unmarshaled, original);
+
+    Ok(())
+}


### PR DESCRIPTION
This change starts the process of implementing a separate trait for marshaling variant data independently of the discriminant. This PR purposefully aims to do the minimal amount of changes so that we can unblock other cleanup in other PRs.

After this PR we will do more cleanup in the repo, and eventually we will separate this out into its own derive proc-macro (and add more thorough unit tests). But to unblock the cleanup of tpm2-rs-base, we need to start with this.

See the discussion about this: https://github.com/tpm-rs/tpm-rs/issues/84

Changes:

*   Added a new trait named `MarshalableVariant`.
*   Added a single test in `tpm2-rs-marshalable`, we can do better here but I'd like to refactor the error codes first, because right now it's hard to work with. So for now, since I'm not making any functional changes, I'd like to do the bare minimum in testing (we'll add more later).