### PR TITLE
Move unsafe discriminant calculation outside tpm-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ hex-literal = { version = "0.4.1" }
 open-enum = "0.4.1"
 proc-macro2 = "1"
 quote = "1"
+safe-discriminant = "0.1.0"
 syn = {version = "2", features = ["full"]}
 trybuild = { version = "1.0.89", features = ["diff"] }
 zerocopy = { version = "0.7.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ hex-literal = { version = "0.4.1" }
 open-enum = "0.4.1"
 proc-macro2 = "1"
 quote = "1"
-safe-discriminant = "0.1.0"
+safe-discriminant = "0.2.0"
 syn = {version = "2", features = ["full"]}
 trybuild = { version = "1.0.89", features = ["diff"] }
 zerocopy = { version = "0.7.0", features = ["derive"] }

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 bitflags = { workspace = true }
 open-enum = { workspace = true }
+safe-discriminant = { workspace = true }
 tpm2-rs-errors = { workspace = true }
 tpm2-rs-marshalable = { workspace = true }
 tpm2-rs-unionify = { workspace = true }

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -7,6 +7,7 @@ use bitflags::bitflags;
 use core::cmp::min;
 use core::mem::size_of;
 use open_enum::open_enum;
+use safe_discriminant::Discriminant;
 pub use tpm2_rs_errors as errors;
 pub use tpm2_rs_marshalable as marshal;
 use tpm2_rs_unionify::UnionSize;
@@ -548,7 +549,7 @@ const TPML_DIGEST_MAX_DIGESTS: usize = 8;
 pub struct TpmsEmpty;
 
 #[repr(C, u16)]
-#[derive(Clone, Copy, PartialEq, Debug, Marshalable, UnionSize)]
+#[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable, UnionSize)]
 pub enum TpmtHa {
     Sha1([u8; constants::TPM2_SHA_DIGEST_SIZE as usize]) = TPM2AlgID::SHA1.0,
     Sha256([u8; constants::TPM2_SHA256_DIGEST_SIZE as usize]) = TPM2AlgID::SHA256.0,
@@ -715,7 +716,7 @@ pub struct TpmsNvCertifyInfo {
 }
 
 #[repr(C, u16)]
-#[derive(Clone, Copy, PartialEq, Marshalable)]
+#[derive(Clone, Copy, PartialEq, Discriminant, Marshalable)]
 pub enum TpmuAttest {
     Certify(TpmsCertifyInfo) = TPM2ST::AttestCertify.0,
     Creation(TpmsCreationInfo) = TPM2ST::AttestCreation.0,
@@ -892,7 +893,7 @@ pub struct TpmsSchemeXor {
 pub type TpmsSchemeHmac = TpmsSchemeHash;
 
 #[repr(C, u16)]
-#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmtKeyedHashScheme {
     Hmac(TpmsSchemeHmac) = TPM2AlgID::HMAC.0,
     ExclusiveOr(TpmsSchemeXor) = TPM2AlgID::XOR.0,
@@ -906,7 +907,7 @@ pub struct TpmsKeyedHashParms {
 }
 
 #[repr(C, u16)]
-#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmtSymDefObject {
     Aes(TpmiAesKeyBits, TpmiAlgSymMode) = TPM2AlgID::AES.0,
     Sm4(TpmiSm4KeyBits, TpmiAlgSymMode) = TPM2AlgID::SM4.0,
@@ -939,7 +940,7 @@ pub type TpmsEncSchemeOaep = TpmsSchemeHash;
 pub type TpmsEncSchemeRsaes = TpmsEmpty;
 
 #[repr(C, u16)]
-#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmtRsaScheme {
     Rsapss(TpmsSigSchemeRsapss) = TPM2AlgID::RSAPSS.0,
     Rsassa(TpmsSigSchemeRsassa) = TPM2AlgID::RSASSA.0,
@@ -962,7 +963,7 @@ pub struct TpmsRsaParms {
 }
 
 #[repr(C, u16)]
-#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmtEccScheme {
     Rsapss(TpmsSigSchemeRsapss) = TPM2AlgID::RSAPSS.0,
     Rsassa(TpmsSigSchemeRsassa) = TPM2AlgID::RSASSA.0,
@@ -981,7 +982,7 @@ pub type TpmsSchemeKdf2 = TpmsSchemeHash;
 pub type TpmsSchemeKdf1Sp800_108 = TpmsSchemeHash;
 
 #[repr(C, u16)]
-#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmtKdfScheme {
     Mgf1(TpmsSchemeMgf1) = TPM2AlgID::MGF1.0,
     Kdf1Sp800_56a(TpmsSchemeKdf1Sp800_56a) = TPM2AlgID::KDF1SP80056A.0,
@@ -1000,7 +1001,7 @@ pub struct TpmsEccParms {
 }
 
 #[repr(C, u16)]
-#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmtAsymScheme {
     Ecdh(TpmsKeySchemeEcdh) = TPM2AlgID::ECDH.0,
     Ecmqv(TpmsKeySchemeEcmqv) = TPM2AlgID::ECMQV.0,
@@ -1032,7 +1033,7 @@ union TpmuPublicId {
 }
 
 #[repr(C, u16)]
-#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum PublicParmsAndId {
     KeyedHash(TpmsKeyedHashParms, Tpm2bDigest) = TPM2AlgID::KeyedHash.0,
     Sym(TpmsSymCipherParms, Tpm2bDigest) = TPM2AlgID::SymCipher.0,
@@ -1097,7 +1098,7 @@ pub struct Tpm2bPrivateVendorSpecific {
 }
 
 #[repr(C, u16)]
-#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmuSensitiveComposite {
     Rsa(Tpm2bPrivateKeyRsa) = TPM2AlgID::RSA.0,
     Ecc(Tpm2bEccParameter) = TPM2AlgID::ECC.0,
@@ -1139,7 +1140,7 @@ impl Marshalable for TpmtSensitive {
 }
 
 #[repr(C, u32)]
-#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmsCapabilityData {
     Algorithms(TpmlAlgProperty) = TPM2Cap::Algs.0,
     Handles(TpmlHandle) = TPM2Cap::Handles.0,

--- a/marshalable/Cargo.toml
+++ b/marshalable/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+safe-discriminant = {workspace = true}
 tpm2-rs-errors = { workspace = true }
 tpm2-rs-marshalable-derive = { workspace = true }

--- a/marshalable/src/lib.rs
+++ b/marshalable/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 
 use core::mem::size_of;
+use safe_discriminant::Discriminant;
 
 use tpm2_rs_errors::*;
 pub use tpm2_rs_marshalable_derive::Marshalable;
@@ -47,22 +48,13 @@ pub trait Marshalable: Sized {
 /// derive proc-macro.
 ///
 /// See: https://github.com/tpm-rs/tpm-rs/issues/84
-pub trait MarshalableVariant: Sized {
-    /// The type responsible for holding the discriminant in the enum.
-    type Selector: Copy;
-
-    /// Returns the discriminant of the current enum.
-    fn discriminant(&self) -> Self::Selector;
-
+pub trait MarshalableVariant: Sized + Discriminant {
     /// Tries to unmarshal into an enum with a specific selector's data.
     ///
     /// Because the way the data in `buffer` is interpreted changes depending on
     /// the variant we are unmarshaling, we have to be told explicitly which
     /// variant is being targeted.
-    fn try_unmarshal_variant(
-        selector: Self::Selector,
-        buffer: &mut UnmarshalBuf,
-    ) -> TpmRcResult<Self>;
+    fn try_unmarshal_variant(selector: Self::Repr, buffer: &mut UnmarshalBuf) -> TpmRcResult<Self>;
 
     /// Only marshals the variant data for the enum.
     ///

--- a/marshalable/src/tests.rs
+++ b/marshalable/src/tests.rs
@@ -238,7 +238,7 @@ fn test_derive_unit_struct() {
 }
 
 #[repr(C, u8)]
-#[derive(Copy, Clone, Debug, Marshalable, PartialEq)]
+#[derive(Copy, Clone, Debug, Discriminant, Marshalable, PartialEq)]
 enum EnumWithVariantData {
     A(u8) = 1,
     B(u8) = 2,


### PR DESCRIPTION
This is following discussions in https://github.com/tpm-rs/tpm-rs/issues/79 This patch dependents on the crate safe-discriminant instead of calculating discriminants on the fly. Objectively, safe-discriminant is not safer than the solution we have. But, it isolates the unsafe code in its separate crate making it easier to review the code and evaluate its safety.

fixes #79