### PR TITLE
Rename `TpmError` to `TssError`

### DIFF
--- a/client-features/src/lib.rs
+++ b/client-features/src/lib.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 use tpm2_rs_base::commands::*;
 use tpm2_rs_base::constants::{TPM2Cap, TPM2PT};
-use tpm2_rs_base::errors::{TpmRcError, TpmResult};
+use tpm2_rs_base::errors::{TpmRcError, TssResult};
 use tpm2_rs_base::TpmsCapabilityData;
 use tpm2_rs_client::*;
 
@@ -10,7 +10,7 @@ use tpm2_rs_client::*;
 // The feature client provides higher-level abstractions than the base TPM client.
 
 // Gets the TPM manufacturer ID.
-pub fn get_manufacturer_id<T>(tpm: &mut T) -> TpmResult<u32>
+pub fn get_manufacturer_id<T>(tpm: &mut T) -> TssResult<u32>
 where
     T: Tpm,
 {

--- a/client-features/src/tests.rs
+++ b/client-features/src/tests.rs
@@ -19,7 +19,7 @@ impl Default for FakeTpm {
     }
 }
 impl Tpm for FakeTpm {
-    fn transact(&mut self, _: &[u8], response: &mut [u8]) -> TpmResult<()> {
+    fn transact(&mut self, _: &[u8], response: &mut [u8]) -> TssResult<()> {
         let mut tx_header = RespHeader {
             tag: TPM2ST::NoSessions,
             size: 0,

--- a/client/src/sessions/mod.rs
+++ b/client/src/sessions/mod.rs
@@ -1,5 +1,5 @@
 use arrayvec::ArrayVec;
-use tpm2_rs_base::errors::{TpmResult, TssTcsError};
+use tpm2_rs_base::errors::{TssResult, TssTcsError};
 use tpm2_rs_base::{
     Tpm2bAuth, Tpm2bNonce, Tpm2bSimple, TpmaSession, TpmiShAuthSession, TpmsAuthCommand,
     TpmsAuthResponse,
@@ -10,7 +10,7 @@ pub trait Session {
     /// Computes the authorization HMAC for this session.
     fn get_auth_command(&self) -> TpmsAuthCommand;
     /// Validates the authorization response for this session.
-    fn validate_auth_response(&self, auth: &TpmsAuthResponse) -> TpmResult<()>;
+    fn validate_auth_response(&self, auth: &TpmsAuthResponse) -> TssResult<()>;
 }
 
 /// Container for sessions associated with a TPM command. A command can have up to three sessions.
@@ -31,7 +31,7 @@ impl Session for PasswordSession {
             hmac: self.auth,
         }
     }
-    fn validate_auth_response(&self, auth: &TpmsAuthResponse) -> TpmResult<()> {
+    fn validate_auth_response(&self, auth: &TpmsAuthResponse) -> TssResult<()> {
         // Password response auth should have empty nonce/hmac and ContinueSession attribute.
         if auth.nonce.get_size() != 0
             || auth.session_attributes.0 != 0x1

--- a/client/src/tests.rs
+++ b/client/src/tests.rs
@@ -8,7 +8,7 @@ use tpm2_rs_base::TpmaSession;
 // A Tpm that just returns a general failure error.
 struct ErrorTpm();
 impl Tpm for ErrorTpm {
-    fn transact(&mut self, _: &[u8], _: &mut [u8]) -> TpmResult<()> {
+    fn transact(&mut self, _: &[u8], _: &mut [u8]) -> TssResult<()> {
         Err(TssTcsError::GeneralFailure.into())
     }
 }
@@ -61,7 +61,7 @@ struct FakeU32LoopbackTpm {
     rxed_bytes: usize,
 }
 impl Tpm for FakeU32LoopbackTpm {
-    fn transact(&mut self, command: &[u8], response: &mut [u8]) -> TpmResult<()> {
+    fn transact(&mut self, command: &[u8], response: &mut [u8]) -> TssResult<()> {
         self.rxed_bytes = command.len();
         let mut buf = UnmarshalBuf::new(command);
         self.rxed_header = Some(CmdHeader::try_unmarshal(&mut buf)?);
@@ -96,7 +96,7 @@ fn test_fake_command() {
 // EvilSizeTpm writes a reponse header with a size value that is larger than the reponse buffer.
 struct EvilSizeTpm();
 impl Tpm for EvilSizeTpm {
-    fn transact(&mut self, _: &[u8], response: &mut [u8]) -> TpmResult<()> {
+    fn transact(&mut self, _: &[u8], response: &mut [u8]) -> TssResult<()> {
         let tx_header = RespHeader {
             tag: TPM2ST::NoSessions,
             size: response.len() as u32 + 2,
@@ -136,7 +136,7 @@ impl Default for FakeTpm {
     }
 }
 impl Tpm for FakeTpm {
-    fn transact(&mut self, _: &[u8], response: &mut [u8]) -> TpmResult<()> {
+    fn transact(&mut self, _: &[u8], response: &mut [u8]) -> TssResult<()> {
         let off = self.header.try_marshal(response)?;
         let length = off + self.len;
         if self.len > response.len() {

--- a/client/tests/simulator_tests.rs
+++ b/client/tests/simulator_tests.rs
@@ -12,7 +12,7 @@
 use std::io::{Error, ErrorKind, IoSlice, Read, Result, Write};
 use std::net::TcpStream;
 use std::process::{Child, Command};
-use tpm2_rs_base::errors::{TpmResult, TssTcsError};
+use tpm2_rs_base::errors::{TssResult, TssTcsError};
 use tpm2_rs_base::{commands::StartupCmd, constants::TPM2SU};
 use tpm2_rs_client::run_command;
 use tpm2_rs_client::Tpm;
@@ -141,7 +141,7 @@ impl TcpTpm {
         })
     }
 
-    fn read_tpm_u32(&mut self) -> TpmResult<u32> {
+    fn read_tpm_u32(&mut self) -> TssResult<u32> {
         let mut val = U32::ZERO;
         self.tpm_conn
             .read_exact(val.as_bytes_mut())
@@ -151,7 +151,7 @@ impl TcpTpm {
 }
 
 impl Tpm for TcpTpm {
-    fn transact(&mut self, command: &[u8], response: &mut [u8]) -> TpmResult<()> {
+    fn transact(&mut self, command: &[u8], response: &mut [u8]) -> TssResult<()> {
         let cmd_size: u32 = command
             .len()
             .try_into()

--- a/errors/src/lib.rs
+++ b/errors/src/lib.rs
@@ -8,30 +8,30 @@ pub use tss_rc::*;
 mod tpm_rc;
 mod tss_rc;
 
-/// Represents success or [`TpmError`] failure, which can happen at any layer.
-pub type TpmResult<T> = Result<T, TpmError>;
+/// Represents success or [`TssError`] failure, which can happen at any layer.
+pub type TssResult<T> = Result<T, TssError>;
 
-/// A TPM error that can occur any any layer, e.g. Service (`TpmRcError`) and Client errors
+/// A TSS error that can occur any any layer, e.g. Service (`TpmRcError`) and Client errors
 /// can be coalesced into this error type.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct TpmError(NonZeroU32);
-impl TpmError {
+pub struct TssError(NonZeroU32);
+impl TssError {
     /// Returns the underlying non-zero `u32`.
     pub const fn get(self) -> u32 {
         self.0.get()
     }
 }
 
-/// Error returned when trying to convert `0` into `TpmError`.
+/// Error returned when trying to convert `0` into `TssError`.
 #[cfg_attr(test, derive(Debug))]
-pub struct TpmErrorCannotBeZero;
+pub struct TssErrorCannotBeZero;
 
-impl TryFrom<u32> for TpmError {
-    type Error = TpmErrorCannotBeZero;
+impl TryFrom<u32> for TssError {
+    type Error = TssErrorCannotBeZero;
     fn try_from(val: u32) -> Result<Self, Self::Error> {
         match NonZeroU32::try_from(val) {
-            Ok(val) => Ok(TpmError(val)),
-            Err(_) => Err(TpmErrorCannotBeZero),
+            Ok(val) => Ok(TssError(val)),
+            Err(_) => Err(TssErrorCannotBeZero),
         }
     }
 }

--- a/errors/src/tpm_rc/mod.rs
+++ b/errors/src/tpm_rc/mod.rs
@@ -225,9 +225,9 @@ impl ErrorPosition {
     }
 }
 
-impl From<TpmRcError> for super::TpmError {
+impl From<TpmRcError> for super::TssError {
     fn from(val: TpmRcError) -> Self {
-        super::TpmError(val.0)
+        super::TssError(val.0)
     }
 }
 

--- a/errors/src/tss_rc.rs
+++ b/errors/src/tss_rc.rs
@@ -47,9 +47,9 @@ macro_rules! generate_tss_layer_error {
             }
         }
 
-        impl From<$error_name> for super::TpmError {
+        impl From<$error_name> for super::TssError {
             fn from(val: $error_name) -> Self {
-                super::TpmError(val.0)
+                super::TssError(val.0)
             }
         }
     };


### PR DESCRIPTION
These types are trying to talk about `TSS` errors, but they are named `TPM` errors which is quite confusing. This rename should help clarify things.

* Rename `TpmError` to `TssError`
* Rename `TpmResult` to `TssResult`

FIXES: #100