### PR TITLE
Rename enum types to be formatted in `UpperPascalCase`

### DIFF
--- a/base/src/commands.rs
+++ b/base/src/commands.rs
@@ -1,11 +1,11 @@
-use crate::constants::{TPM2Cap, TPM2CC, TPM2PT, TPM2SU};
+use crate::constants::{TpmCap, TpmCc, TpmPt, TpmSu};
 use crate::Marshalable;
 use crate::{TpmiYesNo, TpmlDigest, TpmlPcrSelection, TpmsCapabilityData};
 
 /// Trait for a TPM command transaction.
 pub trait TpmCommand: Marshalable {
     /// The command code.
-    const CMD_CODE: TPM2CC;
+    const CMD_CODE: TpmCc;
     /// The command handles type.
     type Handles: Marshalable + Default;
     /// The response parameters type.
@@ -17,10 +17,10 @@ pub trait TpmCommand: Marshalable {
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Marshalable)]
 pub struct StartupCmd {
-    pub startup_type: TPM2SU,
+    pub startup_type: TpmSu,
 }
 impl TpmCommand for StartupCmd {
-    const CMD_CODE: TPM2CC = TPM2CC::Startup;
+    const CMD_CODE: TpmCc = TpmCc::Startup;
     type Handles = ();
     type RespT = ();
     type RespHandles = ();
@@ -29,12 +29,12 @@ impl TpmCommand for StartupCmd {
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Marshalable)]
 pub struct GetCapabilityCmd {
-    pub capability: TPM2Cap,
-    pub property: TPM2PT,
+    pub capability: TpmCap,
+    pub property: TpmPt,
     pub property_count: u32,
 }
 impl TpmCommand for GetCapabilityCmd {
-    const CMD_CODE: TPM2CC = TPM2CC::GetCapability;
+    const CMD_CODE: TpmCc = TpmCc::GetCapability;
     type Handles = ();
     type RespT = GetCapabilityResp;
     type RespHandles = ();
@@ -53,7 +53,7 @@ pub struct PcrReadCmd {
     pcr_selection_in: TpmlPcrSelection,
 }
 impl TpmCommand for PcrReadCmd {
-    const CMD_CODE: TPM2CC = TPM2CC::PCRRead;
+    const CMD_CODE: TpmCc = TpmCc::PCRRead;
     type Handles = ();
     type RespT = PcrReadResp;
     type RespHandles = ();

--- a/base/src/constants.rs
+++ b/base/src/constants.rs
@@ -30,13 +30,13 @@ pub const TPM2_PRIVATE_VENDOR_SPECIFIC_BYTES: u32 = (TPM2_MAX_RSA_KEY_BYTES / 2)
 pub const TPM2_MAX_CONTEXT_SIZE: u32 = 5120;
 pub const TPM2_MAX_ACTIVE_SESSIONS: u32 = 64;
 
-// TPM2AlgID represents a TPM_ALG_ID.
+// TpmAlgId represents a TPM_ALG_ID.
 // See definition in Part 2: Structures, section 6.3.
 #[open_enum]
 #[repr(u16)]
 #[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
 #[derive(Copy, Clone, Default, Marshalable)]
-pub enum TPM2AlgID {
+pub enum TpmAlgId {
     RSA = 0x0001,
     TDES = 0x0003,
     SHA1 = 0x0004,
@@ -78,13 +78,13 @@ pub enum TPM2AlgID {
     ECB = 0x0044,
 }
 
-// TPM2ECCCurve represents a TPM_ECC_Curve.
+// TpmEccCurve represents a TPM_ECC_Curve.
 // See definition in Part 2: Structures, section 6.4.
 #[open_enum]
 #[repr(u16)]
 #[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
 #[derive(Copy, Clone, Default, Marshalable)]
-pub enum TPM2ECCCurve {
+pub enum TpmEccCurve {
     None = 0x0000,
     NistP192 = 0x0001,
     NistP224 = 0x0002,
@@ -95,8 +95,6 @@ pub enum TPM2ECCCurve {
     BNP638 = 0x0011,
     SM2P256 = 0x0020,
 }
-// TODO remove this alias and convert everything to using Command
-pub type TPM2CC = Command;
 
 // The TPM_CC command codes
 // See definition in Part 2: Structures, section 6.5.2.
@@ -104,7 +102,7 @@ pub type TPM2CC = Command;
 #[repr(u32)]
 #[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
 #[derive(Copy, Clone, Default, Marshalable)]
-pub enum Command {
+pub enum TpmCc {
     NVUndefineSpaceSpecial = 0x0000011F,
     EvictControl = 0x00000120,
     HierarchyControl = 0x00000121,
@@ -225,113 +223,113 @@ pub enum Command {
     ACTSetTimeout = 0x00000198,
 }
 
-// TPM2RC represents a TPM_RC.
+// TpmRc represents a TPM_RC.
 // See definition in Part 2: Structures, section 6.6.
 #[open_enum]
 #[repr(u32)]
-pub enum TPM2RC {
+pub enum TpmRc {
     Success = 0x00000000,
     // FMT0 error codes
-    Initialize = TPM2RC::RC_VER_1,
-    Failure = TPM2RC::RC_VER_1 + 0x001,
-    Sequence = TPM2RC::RC_VER_1 + 0x003,
-    Private = TPM2RC::RC_VER_1 + 0x00B,
-    Hmac = TPM2RC::RC_VER_1 + 0x019,
-    Disabled = TPM2RC::RC_VER_1 + 0x020,
-    Exclusive = TPM2RC::RC_VER_1 + 0x021,
-    AuthType = TPM2RC::RC_VER_1 + 0x024,
-    AuthMissing = TPM2RC::RC_VER_1 + 0x025,
-    Policy = TPM2RC::RC_VER_1 + 0x026,
-    Pcr = TPM2RC::RC_VER_1 + 0x027,
-    PCRChanged = TPM2RC::RC_VER_1 + 0x028,
-    Upgrade = TPM2RC::RC_VER_1 + 0x02D,
-    TooManyContexts = TPM2RC::RC_VER_1 + 0x02E,
-    AuthUnavailable = TPM2RC::RC_VER_1 + 0x02F,
-    Reboot = TPM2RC::RC_VER_1 + 0x030,
-    Unbalanced = TPM2RC::RC_VER_1 + 0x031,
-    CommandSize = TPM2RC::RC_VER_1 + 0x042,
-    CommandCode = TPM2RC::RC_VER_1 + 0x043,
-    AuthSize = TPM2RC::RC_VER_1 + 0x044,
-    AuthContext = TPM2RC::RC_VER_1 + 0x045,
-    NVRange = TPM2RC::RC_VER_1 + 0x046,
-    NVSize = TPM2RC::RC_VER_1 + 0x047,
-    NVLocked = TPM2RC::RC_VER_1 + 0x048,
-    NVAuthorization = TPM2RC::RC_VER_1 + 0x049,
-    NVUninitialized = TPM2RC::RC_VER_1 + 0x04A,
-    NVSpace = TPM2RC::RC_VER_1 + 0x04B,
-    NVDefined = TPM2RC::RC_VER_1 + 0x04C,
-    BadContext = TPM2RC::RC_VER_1 + 0x050,
-    CPHash = TPM2RC::RC_VER_1 + 0x051,
-    Parent = TPM2RC::RC_VER_1 + 0x052,
-    NeedsTest = TPM2RC::RC_VER_1 + 0x053,
-    NoResult = TPM2RC::RC_VER_1 + 0x054,
-    Sensitive = TPM2RC::RC_VER_1 + 0x055,
+    Initialize = TpmRc::RC_VER_1,
+    Failure = TpmRc::RC_VER_1 + 0x001,
+    Sequence = TpmRc::RC_VER_1 + 0x003,
+    Private = TpmRc::RC_VER_1 + 0x00B,
+    Hmac = TpmRc::RC_VER_1 + 0x019,
+    Disabled = TpmRc::RC_VER_1 + 0x020,
+    Exclusive = TpmRc::RC_VER_1 + 0x021,
+    AuthType = TpmRc::RC_VER_1 + 0x024,
+    AuthMissing = TpmRc::RC_VER_1 + 0x025,
+    Policy = TpmRc::RC_VER_1 + 0x026,
+    Pcr = TpmRc::RC_VER_1 + 0x027,
+    PCRChanged = TpmRc::RC_VER_1 + 0x028,
+    Upgrade = TpmRc::RC_VER_1 + 0x02D,
+    TooManyContexts = TpmRc::RC_VER_1 + 0x02E,
+    AuthUnavailable = TpmRc::RC_VER_1 + 0x02F,
+    Reboot = TpmRc::RC_VER_1 + 0x030,
+    Unbalanced = TpmRc::RC_VER_1 + 0x031,
+    CommandSize = TpmRc::RC_VER_1 + 0x042,
+    CommandCode = TpmRc::RC_VER_1 + 0x043,
+    AuthSize = TpmRc::RC_VER_1 + 0x044,
+    AuthContext = TpmRc::RC_VER_1 + 0x045,
+    NVRange = TpmRc::RC_VER_1 + 0x046,
+    NVSize = TpmRc::RC_VER_1 + 0x047,
+    NVLocked = TpmRc::RC_VER_1 + 0x048,
+    NVAuthorization = TpmRc::RC_VER_1 + 0x049,
+    NVUninitialized = TpmRc::RC_VER_1 + 0x04A,
+    NVSpace = TpmRc::RC_VER_1 + 0x04B,
+    NVDefined = TpmRc::RC_VER_1 + 0x04C,
+    BadContext = TpmRc::RC_VER_1 + 0x050,
+    CPHash = TpmRc::RC_VER_1 + 0x051,
+    Parent = TpmRc::RC_VER_1 + 0x052,
+    NeedsTest = TpmRc::RC_VER_1 + 0x053,
+    NoResult = TpmRc::RC_VER_1 + 0x054,
+    Sensitive = TpmRc::RC_VER_1 + 0x055,
     // FMT1 error codes
-    CAsymmetric = TPM2RC::RC_FMT_1 + 0x001,
-    Attributes = TPM2RC::RC_FMT_1 + 0x002,
-    Hash = TPM2RC::RC_FMT_1 + 0x003,
-    Value = TPM2RC::RC_FMT_1 + 0x004,
-    Hierarchy = TPM2RC::RC_FMT_1 + 0x005,
-    KeySize = TPM2RC::RC_FMT_1 + 0x007,
-    Mgf = TPM2RC::RC_FMT_1 + 0x008,
-    Mode = TPM2RC::RC_FMT_1 + 0x009,
-    Type = TPM2RC::RC_FMT_1 + 0x00A,
-    Handle = TPM2RC::RC_FMT_1 + 0x00B,
-    Kdf = TPM2RC::RC_FMT_1 + 0x00C,
-    Range = TPM2RC::RC_FMT_1 + 0x00D,
-    AuthFail = TPM2RC::RC_FMT_1 + 0x00E,
-    Nonce = TPM2RC::RC_FMT_1 + 0x00F,
-    PP = TPM2RC::RC_FMT_1 + 0x010,
-    Scheme = TPM2RC::RC_FMT_1 + 0x012,
-    Size = TPM2RC::RC_FMT_1 + 0x015,
-    Symmetric = TPM2RC::RC_FMT_1 + 0x016,
-    Tag = TPM2RC::RC_FMT_1 + 0x017,
-    Selector = TPM2RC::RC_FMT_1 + 0x018,
-    Insufficient = TPM2RC::RC_FMT_1 + 0x01A,
-    Signature = TPM2RC::RC_FMT_1 + 0x01B,
-    Key = TPM2RC::RC_FMT_1 + 0x01C,
-    PolicyFail = TPM2RC::RC_FMT_1 + 0x01D,
-    Integrity = TPM2RC::RC_FMT_1 + 0x01F,
-    Ticket = TPM2RC::RC_FMT_1 + 0x020,
-    ReservedBits = TPM2RC::RC_FMT_1 + 0x021,
-    BadAuth = TPM2RC::RC_FMT_1 + 0x022,
-    Expired = TPM2RC::RC_FMT_1 + 0x023,
-    PolicyCC = TPM2RC::RC_FMT_1 + 0x024,
-    Binding = TPM2RC::RC_FMT_1 + 0x025,
-    Curve = TPM2RC::RC_FMT_1 + 0x026,
-    ECCPoint = TPM2RC::RC_FMT_1 + 0x027,
+    CAsymmetric = TpmRc::RC_FMT_1 + 0x001,
+    Attributes = TpmRc::RC_FMT_1 + 0x002,
+    Hash = TpmRc::RC_FMT_1 + 0x003,
+    Value = TpmRc::RC_FMT_1 + 0x004,
+    Hierarchy = TpmRc::RC_FMT_1 + 0x005,
+    KeySize = TpmRc::RC_FMT_1 + 0x007,
+    Mgf = TpmRc::RC_FMT_1 + 0x008,
+    Mode = TpmRc::RC_FMT_1 + 0x009,
+    Type = TpmRc::RC_FMT_1 + 0x00A,
+    Handle = TpmRc::RC_FMT_1 + 0x00B,
+    Kdf = TpmRc::RC_FMT_1 + 0x00C,
+    Range = TpmRc::RC_FMT_1 + 0x00D,
+    AuthFail = TpmRc::RC_FMT_1 + 0x00E,
+    Nonce = TpmRc::RC_FMT_1 + 0x00F,
+    PP = TpmRc::RC_FMT_1 + 0x010,
+    Scheme = TpmRc::RC_FMT_1 + 0x012,
+    Size = TpmRc::RC_FMT_1 + 0x015,
+    Symmetric = TpmRc::RC_FMT_1 + 0x016,
+    Tag = TpmRc::RC_FMT_1 + 0x017,
+    Selector = TpmRc::RC_FMT_1 + 0x018,
+    Insufficient = TpmRc::RC_FMT_1 + 0x01A,
+    Signature = TpmRc::RC_FMT_1 + 0x01B,
+    Key = TpmRc::RC_FMT_1 + 0x01C,
+    PolicyFail = TpmRc::RC_FMT_1 + 0x01D,
+    Integrity = TpmRc::RC_FMT_1 + 0x01F,
+    Ticket = TpmRc::RC_FMT_1 + 0x020,
+    ReservedBits = TpmRc::RC_FMT_1 + 0x021,
+    BadAuth = TpmRc::RC_FMT_1 + 0x022,
+    Expired = TpmRc::RC_FMT_1 + 0x023,
+    PolicyCC = TpmRc::RC_FMT_1 + 0x024,
+    Binding = TpmRc::RC_FMT_1 + 0x025,
+    Curve = TpmRc::RC_FMT_1 + 0x026,
+    ECCPoint = TpmRc::RC_FMT_1 + 0x027,
     // Warnings
-    ContextGap = TPM2RC::RC_WARN + 0x001,
-    ObjectMemory = TPM2RC::RC_WARN + 0x002,
-    SessionMemory = TPM2RC::RC_WARN + 0x003,
-    Memory = TPM2RC::RC_WARN + 0x004,
-    SessionHandles = TPM2RC::RC_WARN + 0x005,
-    ObjectHandles = TPM2RC::RC_WARN + 0x006,
-    Locality = TPM2RC::RC_WARN + 0x007,
-    Yielded = TPM2RC::RC_WARN + 0x008,
-    Canceled = TPM2RC::RC_WARN + 0x009,
-    Testing = TPM2RC::RC_WARN + 0x00A,
-    ReferenceH0 = TPM2RC::RC_WARN + 0x010,
-    ReferenceH1 = TPM2RC::RC_WARN + 0x011,
-    ReferenceH2 = TPM2RC::RC_WARN + 0x012,
-    ReferenceH3 = TPM2RC::RC_WARN + 0x013,
-    ReferenceH4 = TPM2RC::RC_WARN + 0x014,
-    ReferenceH5 = TPM2RC::RC_WARN + 0x015,
-    ReferenceH6 = TPM2RC::RC_WARN + 0x016,
-    ReferenceS0 = TPM2RC::RC_WARN + 0x018,
-    ReferenceS1 = TPM2RC::RC_WARN + 0x019,
-    ReferenceS2 = TPM2RC::RC_WARN + 0x01A,
-    ReferenceS3 = TPM2RC::RC_WARN + 0x01B,
-    ReferenceS4 = TPM2RC::RC_WARN + 0x01C,
-    ReferenceS5 = TPM2RC::RC_WARN + 0x01D,
-    ReferenceS6 = TPM2RC::RC_WARN + 0x01E,
-    NVRate = TPM2RC::RC_WARN + 0x020,
-    Lockout = TPM2RC::RC_WARN + 0x021,
-    Retry = TPM2RC::RC_WARN + 0x022,
-    NVUnavailable = TPM2RC::RC_WARN + 0x023,
+    ContextGap = TpmRc::RC_WARN + 0x001,
+    ObjectMemory = TpmRc::RC_WARN + 0x002,
+    SessionMemory = TpmRc::RC_WARN + 0x003,
+    Memory = TpmRc::RC_WARN + 0x004,
+    SessionHandles = TpmRc::RC_WARN + 0x005,
+    ObjectHandles = TpmRc::RC_WARN + 0x006,
+    Locality = TpmRc::RC_WARN + 0x007,
+    Yielded = TpmRc::RC_WARN + 0x008,
+    Canceled = TpmRc::RC_WARN + 0x009,
+    Testing = TpmRc::RC_WARN + 0x00A,
+    ReferenceH0 = TpmRc::RC_WARN + 0x010,
+    ReferenceH1 = TpmRc::RC_WARN + 0x011,
+    ReferenceH2 = TpmRc::RC_WARN + 0x012,
+    ReferenceH3 = TpmRc::RC_WARN + 0x013,
+    ReferenceH4 = TpmRc::RC_WARN + 0x014,
+    ReferenceH5 = TpmRc::RC_WARN + 0x015,
+    ReferenceH6 = TpmRc::RC_WARN + 0x016,
+    ReferenceS0 = TpmRc::RC_WARN + 0x018,
+    ReferenceS1 = TpmRc::RC_WARN + 0x019,
+    ReferenceS2 = TpmRc::RC_WARN + 0x01A,
+    ReferenceS3 = TpmRc::RC_WARN + 0x01B,
+    ReferenceS4 = TpmRc::RC_WARN + 0x01C,
+    ReferenceS5 = TpmRc::RC_WARN + 0x01D,
+    ReferenceS6 = TpmRc::RC_WARN + 0x01E,
+    NVRate = TpmRc::RC_WARN + 0x020,
+    Lockout = TpmRc::RC_WARN + 0x021,
+    Retry = TpmRc::RC_WARN + 0x022,
+    NVUnavailable = TpmRc::RC_WARN + 0x023,
 }
 
-impl TPM2RC {
+impl TpmRc {
     pub const RC_VER_1: u32 = 0x00000100;
     pub const RC_FMT_1: u32 = 0x00000080;
     pub const RC_WARN: u32 = 0x00000900;
@@ -339,11 +337,11 @@ impl TPM2RC {
     pub const RC_S: u32 = 0x00000800;
 }
 
-// TPM2EO represents a TPM_EO.
+// TpmEo represents a TPM_EO.
 // See definition in Part 2: Structures, section 6.8.
 #[open_enum]
 #[repr(u16)]
-pub enum TPM2EO {
+pub enum TpmEo {
     Eq = 0x0000,
     Neq = 0x0001,
     SignedGT = 0x0002,
@@ -358,13 +356,13 @@ pub enum TPM2EO {
     BitClear = 0x000B,
 }
 
-// TPM2ST represents a TPM_ST.
+// TpmSt represents a TPM_ST.
 // See definition in Part 2: Structures, section 6.9.
 #[open_enum]
 #[repr(u16)]
 #[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
 #[derive(Copy, Clone, Default, Marshalable)]
-pub enum TPM2ST {
+pub enum TpmSt {
     RspCommand = 0x00C4,
     Null = 0x8000,
     NoSessions = 0x8001,
@@ -385,34 +383,34 @@ pub enum TPM2ST {
     FuManifest = 0x8029,
 }
 
-// TPM2SU represents a TPM_SU.
+// TpmSu represents a TPM_SU.
 // See definition in Part 2: Structures, section 6.10.
 #[open_enum]
 #[repr(u16)]
 #[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
 #[derive(Copy, Clone, Default, Marshalable)]
-pub enum TPM2SU {
+pub enum TpmSu {
     Clear = 0x0000,
     State = 0x0001,
 }
 
-// TPM2SE represents a TPM_SE.
+// TpmSe represents a TPM_SE.
 // See definition in Part 2: Structures, section 6.11.
 #[open_enum]
 #[repr(u8)]
-pub enum TPM2SE {
+pub enum TpmSe {
     HMAC = 0x00,
     Policy = 0x01,
     Trial = 0x03,
 }
 
-// TPM2Cap represents a TPM_CAP.
+// TpmCap represents a TPM_CAP.
 // See definition in Part 2: Structures, section 6.12
 #[open_enum]
 #[repr(u32)]
 #[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
 #[derive(Copy, Clone, Default, Marshalable)]
-pub enum TPM2Cap {
+pub enum TpmCap {
     Algs = 0x00000000,
     Handles = 0x00000001,
     Commands = 0x00000002,
@@ -426,13 +424,13 @@ pub enum TPM2Cap {
     ACT = 0x0000000A,
 }
 
-// TPM2PT represents a TPM_PT.
+// TpmPt represents a TPM_PT.
 // See definition in Part 2: Structures, section 6.13.
 #[open_enum]
 #[repr(u32)]
 #[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
 #[derive(Copy, Clone, Default, Marshalable)]
-pub enum TPM2PT {
+pub enum TpmPt {
     // a 4-octet character string containing the TPM Family value
     // (TPM_SPEC_FAMILY)
     FamilyIndicator = 0x00000100,
@@ -595,13 +593,13 @@ pub enum TPM2PT {
     AuditCounter1 = 0x00000214,
 }
 
-// TPM2PTPCR represents a TPM_PT_PCR.
+// TpmPtPcr represents a TPM_PT_PCR.
 // See definition in Part 2: Structures, section 6.14.
 #[open_enum]
 #[repr(u32)]
 #[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
 #[derive(Copy, Clone, Default, Marshalable)]
-pub enum TPM2PTPCR {
+pub enum TpmPtPcr {
     // a SET bit in the TPMS_PCR_SELECT indicates that the PCR is saved and
     // restored by TPM_SU_STATE
     Save = 0x00000000,
@@ -649,11 +647,11 @@ pub enum TPM2PTPCR {
     Auth = 0x00000014,
 }
 
-// TPM2HT represents a TPM_HT.
+// TpmHt represents a TPM_HT.
 // See definition in Part 2: Structures, section 7.2.
 #[open_enum]
 #[repr(u8)]
-pub enum TPM2HT {
+pub enum TpmHt {
     PCR = 0x00,
     NVIndex = 0x01,
     HMACSession = 0x02,
@@ -664,13 +662,13 @@ pub enum TPM2HT {
     AC = 0x90,
 }
 
-// TPM2Handle represents a TPM_HANDLE.
+// TpmHandle represents a TPM_HANDLE.
 // See definition in Part 2: Structures, section 7.1.
 #[open_enum]
 #[repr(u32)]
 #[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
 #[derive(Copy, Clone, Default, Marshalable)]
-pub enum TPM2Handle {
+pub enum TpmHandle {
     RHOwner = 0x40000001,
     RHNull = 0x40000007,
     RSPW = 0x40000009,
@@ -692,7 +690,7 @@ impl TpmHc {
     /// Handle constant shift.
     const HRShift: u32 = 24;
 
-    const fn new(handle_type: TPM2HT) -> TpmHc {
+    const fn new(handle_type: TpmHt) -> TpmHc {
         TpmHc((handle_type.0 as u32) << TpmHc::HRShift)
     }
 
@@ -701,17 +699,17 @@ impl TpmHc {
     }
 
     /// PCR handle range base.
-    const HRPcr: TpmHc = TpmHc::new(TPM2HT::PCR);
+    const HRPcr: TpmHc = TpmHc::new(TpmHt::PCR);
     /// HMAC session handle range base.
-    const HRHMACSession: TpmHc = TpmHc::new(TPM2HT::HMACSession);
+    const HRHMACSession: TpmHc = TpmHc::new(TpmHt::HMACSession);
     /// Policy session handle range base.
-    const HRPolicySession: TpmHc = TpmHc::new(TPM2HT::PolicySession);
+    const HRPolicySession: TpmHc = TpmHc::new(TpmHt::PolicySession);
     /// Transient object handle range base.
-    const HRTransient: TpmHc = TpmHc::new(TPM2HT::Transient);
+    const HRTransient: TpmHc = TpmHc::new(TpmHt::Transient);
     /// Persistent object handle range base.
-    const HRPersistent: TpmHc = TpmHc::new(TPM2HT::Persistent);
+    const HRPersistent: TpmHc = TpmHc::new(TpmHt::Persistent);
     /// NV index handle range base.
-    const HRNvIndex: TpmHc = TpmHc::new(TPM2HT::NVIndex);
+    const HRNvIndex: TpmHc = TpmHc::new(TpmHt::NVIndex);
     // TODO: Add remaining values and ranges, some of which are profile-dependent.
 
     /// The first HMAC session.
@@ -745,11 +743,11 @@ impl TpmHc {
     }
 }
 
-// TPM2NT represents a TPM_NT.
+// TpmNt represents a TPM_NT.
 // See definition in Part 2: Structures, section 13.4.
 #[open_enum]
 #[repr(u8)]
-pub enum TPM2NT {
+pub enum TpmNt {
     // contains data that is opaque to the TPM that can only be modified
     // using TPM2_NV_Write().
     Ordinary = 0x0,
@@ -771,12 +769,12 @@ pub enum TPM2NT {
     PinPass = 0x9,
 }
 
-/// TPM2Generated represents a TPM_GENERATED.
+/// TpmGenerated represents a TPM_GENERATED.
 /// See definition in Part 2: Structures, section 6.2.
 #[open_enum]
 #[repr(u32)]
 #[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
 #[derive(Copy, Clone, Default, Marshalable)]
-pub enum TPM2Generated {
+pub enum TpmGenerated {
     VALUE = 0xFF544347,
 }

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -115,7 +115,7 @@ impl TpmaNv {
     const NT_SHIFT: u32 = 4;
 
     /// Returns the attribute for an index type (with all other field clear).
-    const fn from_index_type(index_type: TPM2NT) -> TpmaNv {
+    const fn from_index_type(index_type: TpmNt) -> TpmaNv {
         TpmaNv(new_attribute_field(
             index_type.0 as u32,
             Self::NT_MASK,
@@ -124,16 +124,16 @@ impl TpmaNv {
     }
 
     /// Returns the type of the index.
-    pub fn get_index_type(&self) -> TPM2NT {
-        TPM2NT(get_attribute_field(self.0, Self::NT_MASK, Self::NT_SHIFT) as u8)
+    pub fn get_index_type(&self) -> TpmNt {
+        TpmNt(get_attribute_field(self.0, Self::NT_MASK, Self::NT_SHIFT) as u8)
     }
     /// Sets the type of the index.
-    pub fn set_type(&mut self, index_type: TPM2NT) {
+    pub fn set_type(&mut self, index_type: TpmNt) {
         self.0 = set_attribute_field(self.0, index_type.0 as u32, Self::NT_MASK, Self::NT_SHIFT);
     }
 }
-impl From<TPM2NT> for TpmaNv {
-    fn from(value: TPM2NT) -> Self {
+impl From<TpmNt> for TpmaNv {
+    fn from(value: TpmNt) -> Self {
         Self::from_index_type(value)
     }
 }
@@ -145,14 +145,14 @@ impl From<TPM2NT> for TpmaNv {
 #[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
 #[derive(Copy, Clone, PartialEq, Default, Marshalable)]
 pub enum TpmiAlgHash {
-    SHA1 = TPM2AlgID::SHA1.0,
-    SHA256  = TPM2AlgID::SHA256.0,
-    SHA384   = TPM2AlgID::SHA384.0,
-    SHA512 = TPM2AlgID::SHA512.0,
-    SM3256 = TPM2AlgID::SM3256.0,
-    SHA3256 = TPM2AlgID::SHA3256.0,
-    SHA3384 = TPM2AlgID::SHA3384.0,
-    SHA3512 = TPM2AlgID::SHA3512.0,
+    SHA1 = TpmAlgId::SHA1.0,
+    SHA256  = TpmAlgId::SHA256.0,
+    SHA384   = TpmAlgId::SHA384.0,
+    SHA512 = TpmAlgId::SHA512.0,
+    SM3256 = TpmAlgId::SM3256.0,
+    SHA3256 = TpmAlgId::SHA3256.0,
+    SHA3384 = TpmAlgId::SHA3384.0,
+    SHA3512 = TpmAlgId::SHA3512.0,
 }
 
 /// TpmiAlgKdf represents all of key derivation functions (TPMI_ALG_KDF).
@@ -162,10 +162,10 @@ pub enum TpmiAlgHash {
 #[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
 #[derive(Copy, Clone, PartialEq, Default, Marshalable)]
 pub enum TpmiAlgKdf {
-    MGF1 = TPM2AlgID::MGF1.0,
-    KDF1SP80056A = TPM2AlgID::KDF1SP80056A.0,
-    KDF2 = TPM2AlgID::KDF2.0,
-    KDF1SP800108 = TPM2AlgID::KDF1SP800108.0,
+    MGF1 = TpmAlgId::MGF1.0,
+    KDF1SP80056A = TpmAlgId::KDF1SP80056A.0,
+    KDF2 = TpmAlgId::KDF2.0,
+    KDF1SP800108 = TpmAlgId::KDF1SP800108.0,
 }
 
 /// TpmiAlgPublic represents all object types (TPMI_ALG_PUBLIC).
@@ -176,10 +176,10 @@ pub enum TpmiAlgKdf {
 #[derive(Copy, Clone, PartialEq, Default, Marshalable)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum TpmiAlgPublic{
-    RSA = TPM2AlgID::RSA.0,
-    KeyedHash = TPM2AlgID::KeyedHash.0,
-    ECC = TPM2AlgID::ECC.0,
-    SymCipher = TPM2AlgID::SymCipher.0,
+    RSA = TpmAlgId::RSA.0,
+    KeyedHash = TpmAlgId::KeyedHash.0,
+    ECC = TpmAlgId::ECC.0,
+    SymCipher = TpmAlgId::SymCipher.0,
 }
 
 /// TpmiAlgSymMode represents all of block-cipher modes of operation (TPMI_ALG_SYM_MODE).
@@ -190,12 +190,12 @@ pub enum TpmiAlgPublic{
 #[derive(Copy, Clone, PartialEq, Default, Marshalable)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum TpmiAlgSymMode{
-    CMAC = TPM2AlgID::CMAC.0,
-    CTR = TPM2AlgID::CTR.0,
-    OFB = TPM2AlgID::OFB.0,
-    CBC = TPM2AlgID::CBC.0,
-    CFB = TPM2AlgID::CFB.0,
-    ECB = TPM2AlgID::ECB.0,
+    CMAC = TpmAlgId::CMAC.0,
+    CTR = TpmAlgId::CTR.0,
+    OFB = TpmAlgId::OFB.0,
+    CBC = TpmAlgId::CBC.0,
+    CFB = TpmAlgId::CFB.0,
+    ECB = TpmAlgId::ECB.0,
 }
 
 /// TpmiAlgSymObject represents all of the symmetric algorithms that may be used as a companion encryption algortihm for an asymmetric object (TPMI_ALG_SYM_OBJECT).
@@ -206,10 +206,10 @@ pub enum TpmiAlgSymMode{
 #[derive(Copy, Clone, PartialEq, Default, Marshalable)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum TpmiAlgSymObject{
-    TDES = TPM2AlgID::TDES.0,
-    AES = TPM2AlgID::AES.0,
-    SM4 = TPM2AlgID::SM4.0,
-    Camellia = TPM2AlgID::Camellia.0,
+    TDES = TpmAlgId::TDES.0,
+    AES = TpmAlgId::AES.0,
+    SM4 = TpmAlgId::SM4.0,
+    Camellia = TpmAlgId::Camellia.0,
 }
 
 /// TpmiAlgKeyedhashScheme represents values that may appear in a keyed_hash as the scheme parameter (TPMI_ALG_KEYEDHASH_SCHEME).
@@ -220,8 +220,8 @@ pub enum TpmiAlgSymObject{
 #[derive(Copy, Clone, PartialEq, Default, Marshalable)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum TpmiAlgKeyedhashScheme{
-    HMAC = TPM2AlgID::HMAC.0,
-    XOR = TPM2AlgID::XOR.0,
+    HMAC = TpmAlgId::HMAC.0,
+    XOR = TpmAlgId::XOR.0,
 }
 
 /// TpmiAlgRsaScheme represents values that may appear in the scheme parameter of a TpmsRsaParms (TPMI_ALG_RSA_SCHEME).
@@ -232,14 +232,14 @@ pub enum TpmiAlgKeyedhashScheme{
 #[derive(Copy, Clone, PartialEq, Default, Marshalable)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum TpmiAlgRsaScheme{
-    RSAPSS = TPM2AlgID::RSAPSS.0,
-    RSASSA = TPM2AlgID::RSASSA.0,
-    ECDSA = TPM2AlgID::ECDSA.0,
-    ECDAA = TPM2AlgID::ECDAA.0,
-    SM2 = TPM2AlgID::SM2.0,
-    ECSchnorr = TPM2AlgID::ECSchnorr.0,
-    RSAES = TPM2AlgID::RSAES.0,
-    OAEP = TPM2AlgID::OAEP.0,
+    RSAPSS = TpmAlgId::RSAPSS.0,
+    RSASSA = TpmAlgId::RSASSA.0,
+    ECDSA = TpmAlgId::ECDSA.0,
+    ECDAA = TpmAlgId::ECDAA.0,
+    SM2 = TpmAlgId::SM2.0,
+    ECSchnorr = TpmAlgId::ECSchnorr.0,
+    RSAES = TpmAlgId::RSAES.0,
+    OAEP = TpmAlgId::OAEP.0,
 }
 
 /// TpmiAlgEccScheme represents values that may appear in the scheme parameter of a TpmtEccScheme (TPMI_ALG_ECC_SCHEME).
@@ -250,14 +250,14 @@ pub enum TpmiAlgRsaScheme{
 #[derive(Copy, Clone, PartialEq, Default, Marshalable)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum TpmiAlgEccScheme{
-    RSAPSS = TPM2AlgID::RSAPSS.0,
-    RSASSA = TPM2AlgID::RSASSA.0,
-    ECDSA = TPM2AlgID::ECDSA.0,
-    ECDAA = TPM2AlgID::ECDAA.0,
-    SM2 = TPM2AlgID::SM2.0,
-    ECSchnorr = TPM2AlgID::ECSchnorr.0,
-    ECDH = TPM2AlgID::ECDH.0,
-    ECMQV = TPM2AlgID::ECMQV.0,
+    RSAPSS = TpmAlgId::RSAPSS.0,
+    RSASSA = TpmAlgId::RSASSA.0,
+    ECDSA = TpmAlgId::ECDSA.0,
+    ECDAA = TpmAlgId::ECDAA.0,
+    SM2 = TpmAlgId::SM2.0,
+    ECSchnorr = TpmAlgId::ECSchnorr.0,
+    ECDH = TpmAlgId::ECDH.0,
+    ECMQV = TpmAlgId::ECMQV.0,
 }
 
 /// TpmiAlgAsymScheme represents all the scheme types for any asymmetric algortihm (TPMI_ALG_ASYM_SCHEME).
@@ -268,16 +268,16 @@ pub enum TpmiAlgEccScheme{
 #[derive(Copy, Clone, PartialEq, Default, Marshalable)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum TpmiAlgAsymScheme{
-    SM2 = TPM2AlgID::SM2.0,
-    ECDH = TPM2AlgID::ECDH.0,
-    ECMQV = TPM2AlgID::ECMQV.0,
-    RSAPSS = TPM2AlgID::RSAPSS.0,
-    RSASSA = TPM2AlgID::RSASSA.0,
-    ECDSA = TPM2AlgID::ECDSA.0,
-    ECDAA = TPM2AlgID::ECDAA.0,
-    ECSchnorr = TPM2AlgID::ECSchnorr.0,
-    RSAES = TPM2AlgID::RSAES.0,
-    OAEP = TPM2AlgID::OAEP.0,
+    SM2 = TpmAlgId::SM2.0,
+    ECDH = TpmAlgId::ECDH.0,
+    ECMQV = TpmAlgId::ECMQV.0,
+    RSAPSS = TpmAlgId::RSAPSS.0,
+    RSASSA = TpmAlgId::RSASSA.0,
+    ECDSA = TpmAlgId::ECDSA.0,
+    ECDAA = TpmAlgId::ECDAA.0,
+    ECSchnorr = TpmAlgId::ECSchnorr.0,
+    RSAES = TpmAlgId::RSAES.0,
+    OAEP = TpmAlgId::OAEP.0,
 }
 
 /// TpmiRhNvIndex represents an NV location (TPMI_RH_NV_INDEX).
@@ -316,14 +316,14 @@ impl TryFrom<u32> for TpmiShAuthSession {
 }
 impl TpmiShAuthSession {
     /// A password authorization.
-    pub const RS_PW: TpmiShAuthSession = TpmiShAuthSession(TPM2Handle::RSPW.0);
+    pub const RS_PW: TpmiShAuthSession = TpmiShAuthSession(TpmHandle::RSPW.0);
 }
 
 /// TpmiEccCurve represents an implemented ECC curve (TPMI_ECC_SCHEME).
 /// See definition in Part 2: Structures, section 11.2.5.5.
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshalable)]
-pub struct TpmiEccCurve(TPM2ECCCurve);
+pub struct TpmiEccCurve(TpmEccCurve);
 
 /// TpmiYesNo is used in place of a boolean.
 /// See TPMI_YES_NO definition in Part 2: Structures, section 9.2.
@@ -343,14 +343,14 @@ pub enum TpmiYesNo {
 #[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
 #[derive(Copy, Clone, PartialEq, Default, Marshalable)]
 pub enum TpmiStAttest {
-    AttestCertify = TPM2ST::AttestCertify.0,
-    AttestQuote = TPM2ST::AttestQuote.0,
-    AttestSessionAudit = TPM2ST::AttestSessionAudit.0,
-    AttestCommandAudit = TPM2ST::AttestCommandAudit.0,
-    AttestTime = TPM2ST::AttestTime.0,
-    AttestCreation = TPM2ST::AttestCreation.0,
-    AttestNV = TPM2ST::AttestNV.0,
-    AttestNVDigest = TPM2ST::AttestNVDigest.0,
+    AttestCertify = TpmSt::AttestCertify.0,
+    AttestQuote = TpmSt::AttestQuote.0,
+    AttestSessionAudit = TpmSt::AttestSessionAudit.0,
+    AttestCommandAudit = TpmSt::AttestCommandAudit.0,
+    AttestTime = TpmSt::AttestTime.0,
+    AttestCreation = TpmSt::AttestCreation.0,
+    AttestNV = TpmSt::AttestNV.0,
+    AttestNVDigest = TpmSt::AttestNVDigest.0,
 }
 
 /// The number of bits in an AES key.
@@ -529,18 +529,18 @@ impl TpmaCc {
 #[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
 #[derive(Copy, Clone, PartialEq, Default, Marshalable)]
 pub enum TpmiStCommandTag{
-    NoSessions = TPM2ST::NoSessions.0,
-    Sessions = TPM2ST::Sessions.0,
+    NoSessions = TpmSt::NoSessions.0,
+    Sessions = TpmSt::Sessions.0,
 }
 
 const TPM2_MAX_CAP_DATA: usize =
-    TPM2_MAX_CAP_BUFFER as usize - size_of::<TPM2Cap>() - size_of::<u32>();
+    TPM2_MAX_CAP_BUFFER as usize - size_of::<TpmCap>() - size_of::<u32>();
 const TPM2_MAX_CAP_ALGS: usize = TPM2_MAX_CAP_DATA / size_of::<TpmsAlgProperty>();
-const TPM2_MAX_CAP_HANDLES: usize = TPM2_MAX_CAP_DATA / size_of::<TPM2Handle>();
-const TPM2_MAX_CAP_CC: usize = TPM2_MAX_CAP_DATA / size_of::<TPM2CC>();
+const TPM2_MAX_CAP_HANDLES: usize = TPM2_MAX_CAP_DATA / size_of::<TpmHandle>();
+const TPM2_MAX_CAP_CC: usize = TPM2_MAX_CAP_DATA / size_of::<TpmCc>();
 const TPM2_MAX_TPM_PROPERTIES: usize = TPM2_MAX_CAP_DATA / size_of::<TpmsTaggedProperty>();
 const TPM2_MAX_PCR_PROPERTIES: usize = TPM2_MAX_CAP_DATA / size_of::<TpmsTaggedPcrSelect>();
-const TPM2_MAX_ECC_CURVES: usize = TPM2_MAX_CAP_DATA / size_of::<TPM2ECCCurve>();
+const TPM2_MAX_ECC_CURVES: usize = TPM2_MAX_CAP_DATA / size_of::<TpmEccCurve>();
 const TPM2_MAX_TAGGED_POLICIES: usize = TPM2_MAX_CAP_DATA / size_of::<TpmsTaggedPolicy>();
 const TPML_DIGEST_MAX_DIGESTS: usize = 8;
 
@@ -551,11 +551,11 @@ pub struct TpmsEmpty;
 #[repr(C, u16)]
 #[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable, UnionSize)]
 pub enum TpmtHa {
-    Sha1([u8; constants::TPM2_SHA_DIGEST_SIZE as usize]) = TPM2AlgID::SHA1.0,
-    Sha256([u8; constants::TPM2_SHA256_DIGEST_SIZE as usize]) = TPM2AlgID::SHA256.0,
-    Sha384([u8; constants::TPM2_SHA384_DIGEST_SIZE as usize]) = TPM2AlgID::SHA384.0,
-    Sha512([u8; constants::TPM2_SHA512_DIGEST_SIZE as usize]) = TPM2AlgID::SHA512.0,
-    Sm3_256([u8; constants::TPM2_SM3_256_DIGEST_SIZE as usize]) = TPM2AlgID::SM3256.0,
+    Sha1([u8; constants::TPM2_SHA_DIGEST_SIZE as usize]) = TpmAlgId::SHA1.0,
+    Sha256([u8; constants::TPM2_SHA256_DIGEST_SIZE as usize]) = TpmAlgId::SHA256.0,
+    Sha384([u8; constants::TPM2_SHA384_DIGEST_SIZE as usize]) = TpmAlgId::SHA384.0,
+    Sha512([u8; constants::TPM2_SHA512_DIGEST_SIZE as usize]) = TpmAlgId::SHA512.0,
+    Sm3_256([u8; constants::TPM2_SM3_256_DIGEST_SIZE as usize]) = TpmAlgId::SM3256.0,
 }
 
 impl Default for TpmtHa {
@@ -568,7 +568,7 @@ impl Default for TpmtHa {
 #[repr(C, u16)]
 enum TpmuName {
     Digest(TpmtHa),
-    Handle(TPM2Handle),
+    Handle(TpmHandle),
 }
 
 #[repr(C)]
@@ -718,19 +718,19 @@ pub struct TpmsNvCertifyInfo {
 #[repr(C, u16)]
 #[derive(Clone, Copy, PartialEq, Discriminant, Marshalable)]
 pub enum TpmuAttest {
-    Certify(TpmsCertifyInfo) = TPM2ST::AttestCertify.0,
-    Creation(TpmsCreationInfo) = TPM2ST::AttestCreation.0,
-    Quote(TpmsQuoteInfo) = TPM2ST::AttestQuote.0,
-    CommandAudit(TpmsCommandAuditInfo) = TPM2ST::AttestCommandAudit.0,
-    SessionAudit(TpmsSessionAuditInfo) = TPM2ST::AttestSessionAudit.0,
-    Time(TpmsTimeAttestInfo) = TPM2ST::AttestTime.0,
-    Nv(TpmsNvCertifyInfo) = TPM2ST::AttestNV.0,
+    Certify(TpmsCertifyInfo) = TpmSt::AttestCertify.0,
+    Creation(TpmsCreationInfo) = TpmSt::AttestCreation.0,
+    Quote(TpmsQuoteInfo) = TpmSt::AttestQuote.0,
+    CommandAudit(TpmsCommandAuditInfo) = TpmSt::AttestCommandAudit.0,
+    SessionAudit(TpmsSessionAuditInfo) = TpmSt::AttestSessionAudit.0,
+    Time(TpmsTimeAttestInfo) = TpmSt::AttestTime.0,
+    Nv(TpmsNvCertifyInfo) = TpmSt::AttestNV.0,
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq)]
 pub struct TpmsAttest {
-    pub magic: TPM2Generated,
+    pub magic: TpmGenerated,
     pub qualified_signer: Tpm2bName,
     pub extra_data: Tpm2bData,
     pub clock_info: TpmsClockInfo,
@@ -755,7 +755,7 @@ impl Marshalable for TpmsAttest {
     }
 
     fn try_unmarshal(buffer: &mut UnmarshalBuf) -> TpmRcResult<Self> {
-        let magic = TPM2Generated::try_unmarshal(buffer)?;
+        let magic = TpmGenerated::try_unmarshal(buffer)?;
         let selector = u16::try_unmarshal(buffer)?;
         Ok(TpmsAttest {
             magic,
@@ -895,9 +895,9 @@ pub type TpmsSchemeHmac = TpmsSchemeHash;
 #[repr(C, u16)]
 #[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmtKeyedHashScheme {
-    Hmac(TpmsSchemeHmac) = TPM2AlgID::HMAC.0,
-    ExclusiveOr(TpmsSchemeXor) = TPM2AlgID::XOR.0,
-    Null(TpmsEmpty) = TPM2AlgID::Null.0,
+    Hmac(TpmsSchemeHmac) = TpmAlgId::HMAC.0,
+    ExclusiveOr(TpmsSchemeXor) = TpmAlgId::XOR.0,
+    Null(TpmsEmpty) = TpmAlgId::Null.0,
 }
 
 #[repr(C)]
@@ -909,11 +909,11 @@ pub struct TpmsKeyedHashParms {
 #[repr(C, u16)]
 #[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmtSymDefObject {
-    Aes(TpmiAesKeyBits, TpmiAlgSymMode) = TPM2AlgID::AES.0,
-    Sm4(TpmiSm4KeyBits, TpmiAlgSymMode) = TPM2AlgID::SM4.0,
-    Camellia(TpmiCamelliaKeyBits, TpmiAlgSymMode) = TPM2AlgID::Camellia.0,
-    ExclusiveOr(TpmiAlgHash, TpmsEmpty) = TPM2AlgID::XOR.0,
-    Null(TpmsEmpty, TpmsEmpty) = TPM2AlgID::Null.0,
+    Aes(TpmiAesKeyBits, TpmiAlgSymMode) = TpmAlgId::AES.0,
+    Sm4(TpmiSm4KeyBits, TpmiAlgSymMode) = TpmAlgId::SM4.0,
+    Camellia(TpmiCamelliaKeyBits, TpmiAlgSymMode) = TpmAlgId::Camellia.0,
+    ExclusiveOr(TpmiAlgHash, TpmsEmpty) = TpmAlgId::XOR.0,
+    Null(TpmsEmpty, TpmsEmpty) = TpmAlgId::Null.0,
 }
 
 #[repr(C)]
@@ -942,15 +942,15 @@ pub type TpmsEncSchemeRsaes = TpmsEmpty;
 #[repr(C, u16)]
 #[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmtRsaScheme {
-    Rsapss(TpmsSigSchemeRsapss) = TPM2AlgID::RSAPSS.0,
-    Rsassa(TpmsSigSchemeRsassa) = TPM2AlgID::RSASSA.0,
-    Ecdsa(TpmsSigSchemeEcdsa) = TPM2AlgID::ECDSA.0,
-    Ecdaa(TpmsSigSchemeEcdaa) = TPM2AlgID::ECDAA.0,
-    Sm2(TpmsSigSchemeSm2) = TPM2AlgID::SM2.0,
-    Ecschnorr(TpmsSigSchemeEcschnorr) = TPM2AlgID::ECSchnorr.0,
-    Rsaes(TpmsEncSchemeRsaes) = TPM2AlgID::RSAES.0,
-    Oaep(TpmsEncSchemeOaep) = TPM2AlgID::OAEP.0,
-    Null(TpmsEmpty) = TPM2AlgID::Null.0,
+    Rsapss(TpmsSigSchemeRsapss) = TpmAlgId::RSAPSS.0,
+    Rsassa(TpmsSigSchemeRsassa) = TpmAlgId::RSASSA.0,
+    Ecdsa(TpmsSigSchemeEcdsa) = TpmAlgId::ECDSA.0,
+    Ecdaa(TpmsSigSchemeEcdaa) = TpmAlgId::ECDAA.0,
+    Sm2(TpmsSigSchemeSm2) = TpmAlgId::SM2.0,
+    Ecschnorr(TpmsSigSchemeEcschnorr) = TpmAlgId::ECSchnorr.0,
+    Rsaes(TpmsEncSchemeRsaes) = TpmAlgId::RSAES.0,
+    Oaep(TpmsEncSchemeOaep) = TpmAlgId::OAEP.0,
+    Null(TpmsEmpty) = TpmAlgId::Null.0,
 }
 
 #[repr(C)]
@@ -965,15 +965,15 @@ pub struct TpmsRsaParms {
 #[repr(C, u16)]
 #[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmtEccScheme {
-    Rsapss(TpmsSigSchemeRsapss) = TPM2AlgID::RSAPSS.0,
-    Rsassa(TpmsSigSchemeRsassa) = TPM2AlgID::RSASSA.0,
-    Ecdsa(TpmsSigSchemeEcdsa) = TPM2AlgID::ECDSA.0,
-    Ecdaa(TpmsSigSchemeEcdaa) = TPM2AlgID::ECDAA.0,
-    Sm2(TpmsSigSchemeSm2) = TPM2AlgID::SM2.0,
-    Ecschnorr(TpmsSigSchemeEcschnorr) = TPM2AlgID::ECSchnorr.0,
-    Ecdh(TpmsKeySchemeEcdh) = TPM2AlgID::ECDH.0,
-    Ecmqv(TpmsKeySchemeEcmqv) = TPM2AlgID::ECMQV.0,
-    Null(TpmsEmpty) = TPM2AlgID::Null.0,
+    Rsapss(TpmsSigSchemeRsapss) = TpmAlgId::RSAPSS.0,
+    Rsassa(TpmsSigSchemeRsassa) = TpmAlgId::RSASSA.0,
+    Ecdsa(TpmsSigSchemeEcdsa) = TpmAlgId::ECDSA.0,
+    Ecdaa(TpmsSigSchemeEcdaa) = TpmAlgId::ECDAA.0,
+    Sm2(TpmsSigSchemeSm2) = TpmAlgId::SM2.0,
+    Ecschnorr(TpmsSigSchemeEcschnorr) = TpmAlgId::ECSchnorr.0,
+    Ecdh(TpmsKeySchemeEcdh) = TpmAlgId::ECDH.0,
+    Ecmqv(TpmsKeySchemeEcmqv) = TpmAlgId::ECMQV.0,
+    Null(TpmsEmpty) = TpmAlgId::Null.0,
 }
 
 pub type TpmsSchemeMgf1 = TpmsSchemeHash;
@@ -984,11 +984,11 @@ pub type TpmsSchemeKdf1Sp800_108 = TpmsSchemeHash;
 #[repr(C, u16)]
 #[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmtKdfScheme {
-    Mgf1(TpmsSchemeMgf1) = TPM2AlgID::MGF1.0,
-    Kdf1Sp800_56a(TpmsSchemeKdf1Sp800_56a) = TPM2AlgID::KDF1SP80056A.0,
-    Kdf2(TpmsSchemeKdf2) = TPM2AlgID::KDF2.0,
-    Kdf1Sp800_108(TpmsSchemeKdf1Sp800_108) = TPM2AlgID::KDF1SP800108.0,
-    Null(TpmsEmpty) = TPM2AlgID::Null.0,
+    Mgf1(TpmsSchemeMgf1) = TpmAlgId::MGF1.0,
+    Kdf1Sp800_56a(TpmsSchemeKdf1Sp800_56a) = TpmAlgId::KDF1SP80056A.0,
+    Kdf2(TpmsSchemeKdf2) = TpmAlgId::KDF2.0,
+    Kdf1Sp800_108(TpmsSchemeKdf1Sp800_108) = TpmAlgId::KDF1SP800108.0,
+    Null(TpmsEmpty) = TpmAlgId::Null.0,
 }
 
 #[repr(C)]
@@ -1003,17 +1003,17 @@ pub struct TpmsEccParms {
 #[repr(C, u16)]
 #[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmtAsymScheme {
-    Ecdh(TpmsKeySchemeEcdh) = TPM2AlgID::ECDH.0,
-    Ecmqv(TpmsKeySchemeEcmqv) = TPM2AlgID::ECMQV.0,
-    Sm2(TpmsSigSchemeSm2) = TPM2AlgID::SM2.0,
-    Rsapss(TpmsSigSchemeRsapss) = TPM2AlgID::RSAPSS.0,
-    Rsassa(TpmsSigSchemeRsassa) = TPM2AlgID::RSASSA.0,
-    Ecdsa(TpmsSigSchemeEcdsa) = TPM2AlgID::ECDSA.0,
-    Ecdaa(TpmsSigSchemeEcdaa) = TPM2AlgID::ECDAA.0,
-    Ecschnorr(TpmsSigSchemeEcschnorr) = TPM2AlgID::ECSchnorr.0,
-    Rsaes(TpmsEncSchemeRsaes) = TPM2AlgID::RSAES.0,
-    Oaep(TpmsEncSchemeOaep) = TPM2AlgID::OAEP.0,
-    Null(TpmsEmpty) = TPM2AlgID::Null.0,
+    Ecdh(TpmsKeySchemeEcdh) = TpmAlgId::ECDH.0,
+    Ecmqv(TpmsKeySchemeEcmqv) = TpmAlgId::ECMQV.0,
+    Sm2(TpmsSigSchemeSm2) = TpmAlgId::SM2.0,
+    Rsapss(TpmsSigSchemeRsapss) = TpmAlgId::RSAPSS.0,
+    Rsassa(TpmsSigSchemeRsassa) = TpmAlgId::RSASSA.0,
+    Ecdsa(TpmsSigSchemeEcdsa) = TpmAlgId::ECDSA.0,
+    Ecdaa(TpmsSigSchemeEcdaa) = TpmAlgId::ECDAA.0,
+    Ecschnorr(TpmsSigSchemeEcschnorr) = TpmAlgId::ECSchnorr.0,
+    Rsaes(TpmsEncSchemeRsaes) = TpmAlgId::RSAES.0,
+    Oaep(TpmsEncSchemeOaep) = TpmAlgId::OAEP.0,
+    Null(TpmsEmpty) = TpmAlgId::Null.0,
 }
 
 #[repr(C)]
@@ -1035,10 +1035,10 @@ union TpmuPublicId {
 #[repr(C, u16)]
 #[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum PublicParmsAndId {
-    KeyedHash(TpmsKeyedHashParms, Tpm2bDigest) = TPM2AlgID::KeyedHash.0,
-    Sym(TpmsSymCipherParms, Tpm2bDigest) = TPM2AlgID::SymCipher.0,
-    Rsa(TpmsRsaParms, Tpm2bPublicKeyRsa) = TPM2AlgID::RSA.0,
-    Ecc(TpmsEccParms, TpmsEccPoint) = TPM2AlgID::ECC.0,
+    KeyedHash(TpmsKeyedHashParms, Tpm2bDigest) = TpmAlgId::KeyedHash.0,
+    Sym(TpmsSymCipherParms, Tpm2bDigest) = TpmAlgId::SymCipher.0,
+    Rsa(TpmsRsaParms, Tpm2bPublicKeyRsa) = TpmAlgId::RSA.0,
+    Ecc(TpmsEccParms, TpmsEccPoint) = TpmAlgId::ECC.0,
 }
 
 #[repr(C)]
@@ -1100,12 +1100,12 @@ pub struct Tpm2bPrivateVendorSpecific {
 #[repr(C, u16)]
 #[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmuSensitiveComposite {
-    Rsa(Tpm2bPrivateKeyRsa) = TPM2AlgID::RSA.0,
-    Ecc(Tpm2bEccParameter) = TPM2AlgID::ECC.0,
-    Bits(Tpm2bSensitiveData) = TPM2AlgID::KeyedHash.0,
-    Sym(Tpm2bSymKey) = TPM2AlgID::SymCipher.0,
+    Rsa(Tpm2bPrivateKeyRsa) = TpmAlgId::RSA.0,
+    Ecc(Tpm2bEccParameter) = TpmAlgId::ECC.0,
+    Bits(Tpm2bSensitiveData) = TpmAlgId::KeyedHash.0,
+    Sym(Tpm2bSymKey) = TpmAlgId::SymCipher.0,
     /* For size purposes only */
-    Any(Tpm2bPrivateVendorSpecific) = TPM2AlgID::Null.0,
+    Any(Tpm2bPrivateVendorSpecific) = TpmAlgId::Null.0,
 }
 
 #[repr(C)]
@@ -1142,16 +1142,16 @@ impl Marshalable for TpmtSensitive {
 #[repr(C, u32)]
 #[derive(Clone, Copy, PartialEq, Debug, Discriminant, Marshalable)]
 pub enum TpmsCapabilityData {
-    Algorithms(TpmlAlgProperty) = TPM2Cap::Algs.0,
-    Handles(TpmlHandle) = TPM2Cap::Handles.0,
-    Command(TpmlCca) = TPM2Cap::Commands.0,
-    PpCommands(TpmlCc) = TPM2Cap::PPCommands.0,
-    AuditCommands(TpmlCc) = TPM2Cap::AuditCommands.0,
-    AssignedPcr(TpmlPcrSelection) = TPM2Cap::PCRs.0,
-    TpmProperties(TpmlTaggedTpmProperty) = TPM2Cap::TPMProperties.0,
-    PcrProperties(TpmlTaggedPcrProperty) = TPM2Cap::PCRProperties.0,
-    EccCurves(TpmlEccCurve) = TPM2Cap::ECCCurves.0,
-    AuthPolicies(TpmlTaggedPolicy) = TPM2Cap::AuthPolicies.0,
+    Algorithms(TpmlAlgProperty) = TpmCap::Algs.0,
+    Handles(TpmlHandle) = TpmCap::Handles.0,
+    Command(TpmlCca) = TpmCap::Commands.0,
+    PpCommands(TpmlCc) = TpmCap::PPCommands.0,
+    AuditCommands(TpmlCc) = TpmCap::AuditCommands.0,
+    AssignedPcr(TpmlPcrSelection) = TpmCap::PCRs.0,
+    TpmProperties(TpmlTaggedTpmProperty) = TpmCap::TPMProperties.0,
+    PcrProperties(TpmlTaggedPcrProperty) = TpmCap::PCRProperties.0,
+    EccCurves(TpmlEccCurve) = TpmCap::ECCCurves.0,
+    AuthPolicies(TpmlTaggedPolicy) = TpmCap::AuthPolicies.0,
 }
 
 #[repr(C)]
@@ -1167,7 +1167,7 @@ pub struct TpmlAlgProperty {
 pub struct TpmlHandle {
     count: u32,
     #[marshalable(length=count)]
-    handle: [TPM2Handle; TPM2_MAX_CAP_HANDLES],
+    handle: [TpmHandle; TPM2_MAX_CAP_HANDLES],
 }
 
 #[repr(C)]
@@ -1183,7 +1183,7 @@ pub struct TpmlCca {
 pub struct TpmlCc {
     count: u32,
     #[marshalable(length=count)]
-    command_codes: [TPM2CC; TPM2_MAX_CAP_CC],
+    command_codes: [TpmCc; TPM2_MAX_CAP_CC],
 }
 
 #[repr(C)]
@@ -1207,7 +1207,7 @@ pub struct TpmlTaggedPcrProperty {
 pub struct TpmlEccCurve {
     count: u32,
     #[marshalable(length=count)]
-    ecc_curves: [TPM2ECCCurve; TPM2_MAX_ECC_CURVES],
+    ecc_curves: [TpmEccCurve; TPM2_MAX_ECC_CURVES],
 }
 
 #[repr(C)]
@@ -1221,21 +1221,21 @@ pub struct TpmlTaggedPolicy {
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Default, Debug, Marshalable)]
 pub struct TpmsAlgProperty {
-    pub alg: TPM2AlgID,
+    pub alg: TpmAlgId,
     pub alg_properties: TpmaAlgorithm,
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Default, Debug, Marshalable)]
 pub struct TpmsTaggedProperty {
-    pub property: TPM2PT,
+    pub property: TpmPt,
     pub value: u32,
 }
 
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Default, Debug, Marshalable)]
 pub struct TpmsTaggedPcrSelect {
-    tag: TPM2PTPCR,
+    tag: TpmPtPcr,
     size_of_select: u8,
     #[marshalable(length=size_of_select)]
     pcr_select: [u8; TPM2_PCR_SELECT_MAX as usize],
@@ -1244,7 +1244,7 @@ pub struct TpmsTaggedPcrSelect {
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug, Marshalable, Default)]
 pub struct TpmsTaggedPolicy {
-    handle: TPM2Handle,
+    handle: TpmHandle,
     policy_hash: TpmtHa,
 }
 
@@ -1353,7 +1353,7 @@ pub struct TpmsCreationData {
     pub pcr_select: TpmlPcrSelection,
     pub pcr_digest: Tpm2bDigest,
     pub locality: TpmaLocality,
-    pub parent_name_alg: TPM2AlgID,
+    pub parent_name_alg: TpmAlgId,
     pub parent_name: Tpm2bName,
     pub parent_qualified_name: Tpm2bName,
     pub outside_info: Tpm2bData,
@@ -1557,11 +1557,11 @@ macro_rules! impl_tpml {
 }
 impl_tpml! {TpmlPcrSelection, pcr_selections, TpmsPcrSelection, TPM2_NUM_PCR_BANKS}
 impl_tpml! {TpmlAlgProperty, alg_properties, TpmsAlgProperty, TPM2_MAX_CAP_ALGS}
-impl_tpml! {TpmlHandle, handle, TPM2Handle, TPM2_MAX_CAP_HANDLES}
-impl_tpml! {TpmlCc, command_codes, TPM2CC, TPM2_MAX_CAP_CC}
+impl_tpml! {TpmlHandle, handle, TpmHandle, TPM2_MAX_CAP_HANDLES}
+impl_tpml! {TpmlCc, command_codes, TpmCc, TPM2_MAX_CAP_CC}
 impl_tpml! {TpmlTaggedTpmProperty, tpm_property, TpmsTaggedProperty, TPM2_MAX_TPM_PROPERTIES}
 impl_tpml! {TpmlTaggedPcrProperty, pcr_property, TpmsTaggedPcrSelect, TPM2_MAX_PCR_PROPERTIES}
-impl_tpml! {TpmlEccCurve, ecc_curves, TPM2ECCCurve, TPM2_MAX_ECC_CURVES}
+impl_tpml! {TpmlEccCurve, ecc_curves, TpmEccCurve, TPM2_MAX_ECC_CURVES}
 impl_tpml! {TpmlTaggedPolicy, policies, TpmsTaggedPolicy, TPM2_MAX_TAGGED_POLICIES}
 impl_tpml! {TpmlDigest, digests, Tpm2bDigest, TPML_DIGEST_MAX_DIGESTS}
 

--- a/base/src/tests.rs
+++ b/base/src/tests.rs
@@ -180,8 +180,8 @@ fn test_try_unmarshal_tpm2b_template() {
 
 #[test]
 fn test_impl_tpml_new() {
-    let elements: Vec<TPM2Handle> = (0..TPM2_MAX_CAP_HANDLES + 1)
-        .map(|i| TPM2Handle(i as u32))
+    let elements: Vec<TpmHandle> = (0..TPM2_MAX_CAP_HANDLES + 1)
+        .map(|i| TpmHandle(i as u32))
         .collect();
     for x in 0..TPM2_MAX_CAP_HANDLES {
         let slice = &elements.as_slice()[..x];
@@ -197,8 +197,8 @@ fn test_impl_tpml_new() {
 
 #[test]
 fn test_impl_tpml_default_add() {
-    let elements: Vec<TPM2Handle> = (0..TPM2_MAX_CAP_HANDLES + 1)
-        .map(|i| TPM2Handle(i as u32))
+    let elements: Vec<TpmHandle> = (0..TPM2_MAX_CAP_HANDLES + 1)
+        .map(|i| TpmHandle(i as u32))
         .collect();
     let mut list = TpmlHandle::default();
     for x in 0..TPM2_MAX_CAP_HANDLES {
@@ -300,7 +300,7 @@ fn test_marshal_tpmt_public() {
     assert_eq!(remarsh_buffer[..marsh.unwrap()], buffer[..marsh.unwrap()]);
 
     // Test invalid selector value.
-    assert!(TPM2AlgID::SHA256.try_marshal(&mut buffer).is_ok());
+    assert!(TpmAlgId::SHA256.try_marshal(&mut buffer).is_ok());
     unmarsh = TpmtPublic::try_unmarshal(&mut UnmarshalBuf::new(&buffer));
     assert_eq!(unmarsh.err(), Some(TpmRcError::Selector));
 }
@@ -343,7 +343,7 @@ fn test_2b_struct() {
         pcr_digest: Tpm2bDigest::from_bytes(&[0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9])
             .unwrap(),
         locality: TpmaLocality(0xA),
-        parent_name_alg: TPM2AlgID::SHA384,
+        parent_name_alg: TpmAlgId::SHA384,
         parent_name: Tpm2bName::from_bytes(&[0xA, 0xB, 0xC, 0xD, 0xE, 0xF]).unwrap(),
         parent_qualified_name: Tpm2bName::default(),
         outside_info: Tpm2bData::from_bytes(&[0x1; 32]).unwrap(),

--- a/client-features/src/lib.rs
+++ b/client-features/src/lib.rs
@@ -1,6 +1,6 @@
 #![forbid(unsafe_code)]
 use tpm2_rs_base::commands::*;
-use tpm2_rs_base::constants::{TPM2Cap, TPM2PT};
+use tpm2_rs_base::constants::{TpmCap, TpmPt};
 use tpm2_rs_base::errors::{TpmRcError, TssResult};
 use tpm2_rs_base::TpmsCapabilityData;
 use tpm2_rs_client::*;
@@ -15,8 +15,8 @@ where
     T: Tpm,
 {
     const CMD: GetCapabilityCmd = GetCapabilityCmd {
-        capability: TPM2Cap::TPMProperties,
-        property: TPM2PT::Manufacturer,
+        capability: TpmCap::TPMProperties,
+        property: TpmPt::Manufacturer,
         property_count: 1,
     };
     let resp = run_command(&CMD, tpm)?;

--- a/client-features/src/tests.rs
+++ b/client-features/src/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use tpm2_rs_base::constants::{TPM2AlgID, TPM2ST};
+use tpm2_rs_base::constants::{TpmAlgId, TpmSt};
 use tpm2_rs_base::marshal::Marshalable;
 use tpm2_rs_base::{
     TpmaAlgorithm, TpmiYesNo, TpmlAlgProperty, TpmlTaggedTpmProperty, TpmsAlgProperty,
@@ -21,7 +21,7 @@ impl Default for FakeTpm {
 impl Tpm for FakeTpm {
     fn transact(&mut self, _: &[u8], response: &mut [u8]) -> TssResult<()> {
         let mut tx_header = RespHeader {
-            tag: TPM2ST::NoSessions,
+            tag: TpmSt::NoSessions,
             size: 0,
             rc: 0,
         };
@@ -44,7 +44,7 @@ fn test_get_manufacturer_too_many_properties() {
         capability_data: TpmsCapabilityData::TpmProperties(
             TpmlTaggedTpmProperty::new(
                 &[TpmsTaggedProperty {
-                    property: TPM2PT::Manufacturer,
+                    property: TpmPt::Manufacturer,
                     value: 4,
                 }; 6],
             )
@@ -63,7 +63,7 @@ fn test_get_manufacturer_wrong_type_properties() {
         more_data: TpmiYesNo::NO,
         capability_data: TpmsCapabilityData::Algorithms(
             TpmlAlgProperty::new(&[TpmsAlgProperty {
-                alg: TPM2AlgID::SHA256,
+                alg: TpmAlgId::SHA256,
                 alg_properties: TpmaAlgorithm::empty(),
             }])
             .unwrap(),

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -3,7 +3,7 @@
 use core::mem::size_of;
 use sessions::CmdSessions;
 use tpm2_rs_base::commands::*;
-use tpm2_rs_base::constants::{TPM2CC, TPM2ST};
+use tpm2_rs_base::constants::{TpmCc, TpmSt};
 use tpm2_rs_base::errors::{TssError, TssResult, TssTcsError};
 use tpm2_rs_base::marshal::{Marshalable, UnmarshalBuf};
 use tpm2_rs_base::{TpmiStCommandTag, TpmsAuthResponse};
@@ -29,10 +29,10 @@ pub fn get_capability<T: Tpm>(
 pub struct CmdHeader {
     tag: TpmiStCommandTag,
     size: u32,
-    code: TPM2CC,
+    code: TpmCc,
 }
 impl CmdHeader {
-    fn new(has_sessions: bool, code: TPM2CC) -> CmdHeader {
+    fn new(has_sessions: bool, code: TpmCc) -> CmdHeader {
         let tag = if has_sessions {
             TpmiStCommandTag::NoSessions
         } else {
@@ -45,7 +45,7 @@ impl CmdHeader {
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Marshalable, Debug)]
 pub struct RespHeader {
-    pub tag: TPM2ST,
+    pub tag: TpmSt,
     pub size: u32,
     pub rc: u32,
 }
@@ -129,7 +129,7 @@ where
     }
     let mut unmarsh = UnmarshalBuf::new(&resp_buffer[read..resp_size]);
     let resp_handles = CmdT::RespHandles::try_unmarshal(&mut unmarsh)?;
-    if resp_header.tag == TPM2ST::Sessions {
+    if resp_header.tag == TpmSt::Sessions {
         let _param_size = u32::try_unmarshal(&mut unmarsh)?;
     }
     let resp = CmdT::RespT::try_unmarshal(&mut unmarsh)?;

--- a/client/tests/simulator_tests.rs
+++ b/client/tests/simulator_tests.rs
@@ -13,7 +13,7 @@ use std::io::{Error, ErrorKind, IoSlice, Read, Result, Write};
 use std::net::TcpStream;
 use std::process::{Child, Command};
 use tpm2_rs_base::errors::{TssResult, TssTcsError};
-use tpm2_rs_base::{commands::StartupCmd, constants::TPM2SU};
+use tpm2_rs_base::{commands::StartupCmd, constants::TpmSu};
 use tpm2_rs_client::run_command;
 use tpm2_rs_client::Tpm;
 use tpm2_rs_client_features::*;
@@ -35,7 +35,7 @@ fn get_simulator_path() -> String {
 fn test_startup_tpm() {
     let (_sim_lifeline, mut tpm) = run_tpm_simulator(&get_simulator_path()).unwrap();
     let startup = StartupCmd {
-        startup_type: TPM2SU::Clear,
+        startup_type: TpmSu::Clear,
     };
     assert!(run_command(&startup, &mut tpm).is_ok());
 }
@@ -44,7 +44,7 @@ fn test_startup_tpm() {
 fn get_started_tpm() -> (TpmSim, TcpTpm) {
     let (sim_lifeline, mut tpm) = run_tpm_simulator(&get_simulator_path()).unwrap();
     let startup = StartupCmd {
-        startup_type: TPM2SU::Clear,
+        startup_type: TpmSu::Clear,
     };
     run_command(&startup, &mut tpm).unwrap();
     (sim_lifeline, tpm)

--- a/service/src/service.rs
+++ b/service/src/service.rs
@@ -3,7 +3,7 @@ use crate::buffer::{
 };
 use crate::crypto::Crypto;
 use crate::handler::{self, CommandContext, ContextDeps};
-use tpm2_rs_base::constants::Command;
+use tpm2_rs_base::constants::TpmCc;
 use tpm2_rs_base::errors::TpmRcError;
 
 /// Specifies all of the dependent types for `Service`.
@@ -80,8 +80,8 @@ impl<'a, Deps: ServiceDeps> Service<'a, Deps> {
             crypto: self.crypto,
         };
 
-        match Command(command_code) {
-            Command::GetRandom => handler::get_random(request, context),
+        match TpmCc(command_code) {
+            TpmCc::GetRandom => handler::get_random(request, context),
             _ => Err(TpmRcError::CommandCode),
         }?;
 


### PR DESCRIPTION
This change updates the typenames to be formatted as appropriate for rust enum types. It also removes the prefixing of `TPM2`, instead opting for just `Tpm` (most of these types were originally just named `TPM_*`, so I think this is appropriate).

One other minor changes fell out of this:

*   There's no longer a `TpmCc` and a `Command` alias, we are
    canonicalizing to the formal name from the spec (`TpmCc`).

FIXES: #98