### PR TITLE
Make the link clickable in docs and add CI to catch documentation issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,19 @@ jobs:
         with:
           command: clippy
           args: --all-targets -- -D warnings
+
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc

--- a/marshalable/src/lib.rs
+++ b/marshalable/src/lib.rs
@@ -47,7 +47,7 @@ pub trait Marshalable: Sized {
 /// However, in the future we will be separating this out into a different
 /// derive proc-macro.
 ///
-/// See: https://github.com/tpm-rs/tpm-rs/issues/84
+/// See: <https://github.com/tpm-rs/tpm-rs/issues/84>
 pub trait MarshalableVariant: Sized + Discriminant {
     /// Tries to unmarshal into an enum with a specific selector's data.
     ///


### PR DESCRIPTION
Btw the CI uses `actions-rs/cargo` action which, according to the repo, is deprecated: https://github.com/actions-rs/cargo

I think converting to plain cargo invocations would be a good idea (but I didn't want to spam this PR with too many changes at once).