### PR TITLE
Improve API for password sessions

### DIFF
--- a/client/src/sessions/password.rs
+++ b/client/src/sessions/password.rs
@@ -12,7 +12,7 @@ use tpm2_rs_base::{
 /// use tpm2_rs_client::sessions::PasswordSession;
 ///
 /// let password1 = PasswordSession::new("hello world").unwrap(); // from a string
-/// let password2 = PasswordSession::new([1, 2, 3, 4, 5, 6]).unwrap(); // from a byte array
+/// let password2 = PasswordSession::new(&[1, 2, 3, 4, 5, 6]).unwrap(); // from a byte array
 ///
 /// assert_eq!(password1.get_secret(), b"hello world");
 /// assert_eq!(password2.get_secret(), &[1, 2, 3, 4, 5, 6]);
@@ -29,7 +29,7 @@ impl PasswordSession {
     /// # Errors:
     /// Returns [`tpm2_rs_base::errors::TpmRcError::Size`] if the
     /// password size in bytes exceeds [`Tpm2bAuth::MAX_BUFFER_SIZE`].
-    pub fn new<T: AsRef<[u8]>>(password: T) -> TpmRcResult<Self> {
+    pub fn new<T: AsRef<[u8]> + ?Sized>(password: &T) -> TpmRcResult<Self> {
         Ok(PasswordSession {
             auth: Tpm2bAuth::from_bytes(password.as_ref())?,
         })

--- a/client/src/sessions/password.rs
+++ b/client/src/sessions/password.rs
@@ -1,14 +1,43 @@
 use crate::sessions::Session;
-use tpm2_rs_base::errors::{TssResult, TssTcsError};
+use tpm2_rs_base::errors::{TpmRcResult, TssResult, TssTcsError};
 use tpm2_rs_base::{
     Tpm2bAuth, Tpm2bNonce, Tpm2bSimple, TpmaSession, TpmiShAuthSession, TpmsAuthCommand,
     TpmsAuthResponse,
 };
 
 /// A password session.
+///
+/// # Usage:
+/// ```
+/// use tpm2_rs_client::sessions::PasswordSession;
+///
+/// let password1 = PasswordSession::new("hello world").unwrap(); // from a string
+/// let password2 = PasswordSession::new([1, 2, 3, 4, 5, 6]).unwrap(); // from a byte array
+///
+/// assert_eq!(password1.get_secret(), b"hello world");
+/// assert_eq!(password2.get_secret(), &[1, 2, 3, 4, 5, 6]);
+/// ```
 #[derive(Debug, PartialEq, Default)]
 pub struct PasswordSession {
-    pub auth: Tpm2bAuth,
+    auth: Tpm2bAuth,
+}
+
+impl PasswordSession {
+    /// This function creates a new password session using the
+    /// specified password.
+    ///
+    /// # Errors:
+    /// Returns [`tpm2_rs_base::errors::TpmRcError::Size`] if the
+    /// password size in bytes exceeds [`Tpm2bAuth::MAX_BUFFER_SIZE`].
+    pub fn new<T: AsRef<[u8]>>(password: T) -> TpmRcResult<Self> {
+        Ok(PasswordSession {
+            auth: Tpm2bAuth::from_bytes(password.as_ref())?,
+        })
+    }
+    /// This function returns the data(password) stored inside a password session
+    pub fn get_secret(&self) -> &[u8] {
+        self.auth.get_buffer()
+    }
 }
 
 impl Session for PasswordSession {

--- a/client/src/sessions/password.rs
+++ b/client/src/sessions/password.rs
@@ -27,8 +27,20 @@ impl PasswordSession {
     /// specified password.
     ///
     /// # Errors:
-    /// Returns [`tpm2_rs_base::errors::TpmRcError::Size`] if the
+    /// Returns [TpmRcError::Size](tpm2_rs_base::errors::TpmRcError::Size) if the
     /// password size in bytes exceeds [`Tpm2bAuth::MAX_BUFFER_SIZE`].
+    ///
+    /// ```
+    /// use tpm2_rs_base::{errors::TpmRcError, Tpm2bAuth, Tpm2bSimple};
+    /// use tpm2_rs_client::sessions::PasswordSession;
+    ///
+    /// let bad_password = [0u8; Tpm2bAuth::MAX_BUFFER_SIZE + 1];
+    /// assert_eq!(
+    ///     PasswordSession::new(&bad_password).err().unwrap(),
+    ///     TpmRcError::Size
+    /// );
+
+    /// ```
     pub fn new<T: AsRef<[u8]> + ?Sized>(password: &T) -> TpmRcResult<Self> {
         Ok(PasswordSession {
             auth: Tpm2bAuth::from_bytes(password.as_ref())?,

--- a/client/src/sessions/tests.rs
+++ b/client/src/sessions/tests.rs
@@ -1,13 +1,12 @@
-use tpm2_rs_base::{Tpm2bAuth, Tpm2bSimple, TpmiShAuthSession};
+use tpm2_rs_base::{Tpm2bSimple, TpmiShAuthSession};
 
 use super::*;
 
 #[test]
 fn test_password_get_auth_command() {
-    let auth = Tpm2bAuth::from_bytes("hello".as_bytes()).unwrap();
-    let session = PasswordSession { auth };
-
+    let session = PasswordSession::new("hello").unwrap();
     let tpm_auth = session.get_auth_command();
     assert_eq!(tpm_auth.session_handle, TpmiShAuthSession::RS_PW);
-    assert_eq!(auth, tpm_auth.hmac);
+    assert_eq!(tpm_auth.hmac.get_size(), 5);
+    assert_eq!(tpm_auth.hmac.get_buffer(), b"hello");
 }


### PR DESCRIPTION
Idea originated from discussion at [1] to make the internal Tpm2bAuth inside a password session hidden. All users need to do is create a password and (possibly) fetch secrets stored inside. without having to worry about the internal marshalable structure required by TPM specifications.

[1] https://github.com/tpm-rs/tpm-rs/pull/95#discussion_r1772048874