### PR TITLE
server: eleminate ContextDeps trait

### DIFF
--- a/server/src/handler/mod.rs
+++ b/server/src/handler/mod.rs
@@ -1,12 +1,12 @@
 use crate::{
-    platform::{ContextDeps, CryptoRandom, TpmBuffers},
+    platform::{CryptoRandom, ServiceDeps, TpmBuffers},
     req_resp::RequestThenResponse,
 };
 use tpm2_rs_base::errors::TpmRcError;
 
 /// The context that all command handler functions are given access to in order for them to process
 /// their given command.
-pub struct CommandContext<'a, Deps: ContextDeps> {
+pub struct CommandContext<'a, Deps: ServiceDeps> {
     /// Gives access to cryptographic operations.
     pub crypto: &'a mut Deps::Crypto,
 }
@@ -14,7 +14,7 @@ pub struct CommandContext<'a, Deps: ContextDeps> {
 /// Handles the `TPM_CC_GetRandom` (`0x17B`) command.
 pub fn get_random(
     request_response: RequestThenResponse<impl TpmBuffers>,
-    context: &mut CommandContext<impl ContextDeps>,
+    context: &mut CommandContext<impl ServiceDeps>,
 ) -> Result<(), TpmRcError> {
     let mut request = request_response;
     let requested_bytes = request.read_be_u16().ok_or(TpmRcError::CommandSize)? as usize;

--- a/server/src/platform/mod.rs
+++ b/server/src/platform/mod.rs
@@ -13,16 +13,3 @@ pub trait ServiceDeps {
     /// The type of the output response buffer for command processing.
     type Response: TpmWriteBuffer + ?Sized;
 }
-
-/// Specifies all of the dependent types for the `CommandContext` parameter that all command handler
-/// functions get access to to handle their specific command.
-pub trait ContextDeps {
-    /// Interface to perform cryptographic operations.
-    type Crypto: Crypto;
-}
-
-// Implement the `ContextDeps` for all types that implement `ServiceDeps` since ContextDeps is a
-// subset.
-impl<T: ServiceDeps> ContextDeps for T {
-    type Crypto = T::Crypto;
-}


### PR DESCRIPTION
ContextDeps is redundant, in practice any server implementation must implement ServiceDeps even for unit tests we would have a full ServiceDeps which makes ContextDeps unnecessary at least at this point in time.