### PR TITLE
server: Hide unnecessary modules

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -3,7 +3,8 @@
 
 mod handler;
 pub mod platform;
-pub mod req_resp;
+mod req_resp;
 #[cfg(test)]
 mod tests;
-pub mod tpmctx;
+mod tpmctx;
+pub use tpmctx::TpmContext;

--- a/server/src/req_resp.rs
+++ b/server/src/req_resp.rs
@@ -52,6 +52,10 @@ impl<'a, B: TpmBuffers> Response<'a, B> {
     /// Writes the specified `data` at the last written location and updates the internal
     /// last written location. Returns [`WriteOutOfBounds`] if write would have written past the the
     /// of the underlying [`TpmWriteBuffer`].
+    #[expect(
+        dead_code,
+        reason = "This function may be used later in the future, but it is not yet"
+    )]
     pub fn write(&mut self, data: &[u8]) -> Result<(), WriteOutOfBounds> {
         self.buffers
             .buffers


### PR DESCRIPTION
In principle users need to be only aware of two parts of the server:
- The TpmContext structure which is the top level tpm implementation. It consumes byte-array-like structures representing tpm commands and produces byte-array-like structures representing tpm responses.
- The plaform module which represent the HAL layer.

Everything else can be hidden. In doing so, we discovered one method the `Response::write()` which no-one uses so far. So we make overwrite lints for that one function to allow it being deadcode.