### PR TITLE
Add structures for TPM2_GetRandom command.

### DIFF
--- a/base/src/commands/random.rs
+++ b/base/src/commands/random.rs
@@ -1,7 +1,27 @@
 //! [TPM2.0 1.83] 16 Random Number Generator
 
+use crate::commands::{Marshalable, TpmCommand};
+use crate::constants::TpmCc;
+use crate::Tpm2bDigest;
+
 /// [TPM2.0 1.83] 16.1 TPM2_GetRandom (Command)
-pub struct GetRandomCmd {}
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+pub struct GetRandomCmd {
+    pub bytes_requested: u16,
+}
+impl TpmCommand for GetRandomCmd {
+    const CMD_CODE: TpmCc = TpmCc::GetRandom;
+    type Handles = ();
+    type RespT = GetRandomResp;
+    type RespHandles = ();
+}
+/// [TPM2.0 1.83] 16.1 TPM2_GetRandom (Response)
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+pub struct GetRandomResp {
+    pub random_bytes: Tpm2bDigest,
+}
 
 /// [TPM2.0 1.83] 16.2 TPM2_StirRandom (Command)
 pub struct StirRandomCmd {}

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -12,3 +12,4 @@ tpm2-rs-marshalable = { workspace = true }
 
 [dev-dependencies]
 zerocopy = { workspace = true }
+tpm2-rs-unionify = { workspace = true }

--- a/client/tests/simulator_tests_registration/capability.rs
+++ b/client/tests/simulator_tests_registration/capability.rs
@@ -1,0 +1,39 @@
+use crate::get_started_tpm;
+use tpm2_rs_base::commands::GetCapabilityCmd;
+use tpm2_rs_base::constants::{TpmCap, TpmPt};
+use tpm2_rs_base::{TpmlTaggedTpmProperty, TpmsCapabilityData, TpmsTaggedProperty};
+use tpm2_rs_client::run_command;
+
+#[test]
+fn test_get_capability_manufacturer_id() {
+    let (_sim_lifeline, mut tpm) = get_started_tpm();
+
+    let mut expected = TpmlTaggedTpmProperty {
+        count: 1,
+        tpm_property: [TpmsTaggedProperty::default(); 127],
+    };
+
+    expected.tpm_property[0] = TpmsTaggedProperty {
+        property: TpmPt::Manufacturer,
+        value: 0x58595A20,
+    };
+
+    let command = GetCapabilityCmd {
+        capability: TpmCap::TPMProperties,
+        property: TpmPt::Manufacturer,
+        property_count: 1,
+    };
+
+    // We allow panic in test cases.
+    let resp = run_command(&command, &mut tpm).expect("Failed running command.");
+
+    // Extract the TpmlTaggedTpmProperty data form the response.
+    let TpmsCapabilityData::TpmProperties(received) = resp.capability_data else {
+        panic!("Unexpected variant data.")
+    };
+
+    assert_eq!(
+        received, expected,
+        "Received did not match the expected response."
+    );
+}

--- a/client/tests/simulator_tests_registration/mod.rs
+++ b/client/tests/simulator_tests_registration/mod.rs
@@ -1,0 +1,10 @@
+//! Please see "simulator_tests.rs" for details.
+//!
+//! Add at least one test module file for each chapter in TPM command spec.
+//! If there are many tests for a single command, it is recommended to split into command submodules:
+//!
+//! <chaptername>/mod.rs
+//! <chaptername>/<commandname_1>.rs
+//! <chaptername>/<commandname_2>.rs
+pub mod capability;
+pub mod random;

--- a/client/tests/simulator_tests_registration/random.rs
+++ b/client/tests/simulator_tests_registration/random.rs
@@ -1,0 +1,95 @@
+use crate::get_started_tpm;
+use tpm2_rs_base::commands::GetRandomCmd;
+use tpm2_rs_base::constants::TPM2_SHA256_DIGEST_SIZE;
+use tpm2_rs_base::TpmtHa;
+use tpm2_rs_client::run_command;
+use tpm2_rs_unionify::UnionSize;
+
+#[test]
+fn test_get_random_duplicate_value_trap() {
+    let (_sim_lifeline, mut tpm) = get_started_tpm();
+
+    let command = GetRandomCmd {
+        bytes_requested: TPM2_SHA256_DIGEST_SIZE as u16,
+    };
+
+    let resp = run_command(&command, &mut tpm).expect("Failed running command.");
+
+    // Lets pull out the actual data as a slice for convenience
+    let random_slice = &resp.random_bytes.as_ref();
+
+    assert_eq!(
+        random_slice.len(),
+        TPM2_SHA256_DIGEST_SIZE as usize,
+        "We should have received exactly size of SHA256 bytes, but got {}.",
+        random_slice.len()
+    );
+
+    // Duplicate value trap, to catch any same value sequences.
+    let same_twice_occurrences = random_slice
+        .iter()
+        .zip(random_slice.iter().skip(1))
+        .filter(|(prev, curr)| prev == curr)
+        .count();
+
+    assert!(
+        same_twice_occurrences < (random_slice.len() / 2).into(),
+        "More than 50% of the values equals previous value: {random_slice:?}"
+    );
+}
+
+#[test]
+fn test_get_random_large_sizes() {
+    let (_sim_lifeline, mut tpm) = get_started_tpm();
+    let mut detected_max_size = 0;
+
+    // The first value is used to detect the servers max digest size.
+    // The second value is used to confirm that server is still providing that size.
+    for i in [0xFFF, 0xFFFF] {
+        let command = GetRandomCmd { bytes_requested: i };
+        let resp = run_command(&command, &mut tpm).expect("Failed running command.");
+
+        // Lets pull out the actual slice size for convenience
+        let random_slice_len = resp.random_bytes.as_ref().len();
+
+        if detected_max_size == 0 {
+            // Detect the max size used by the server.
+            assert!(
+                TpmtHa::UNION_SIZE as usize >= random_slice_len,
+                "We received more random data, than client implementation supports {random_slice_len} > {}.",
+                TpmtHa::UNION_SIZE
+            );
+
+            assert!(
+                TPM2_SHA256_DIGEST_SIZE as usize <= random_slice_len,
+                "We should have received at least size of SHA256 bytes, but got {random_slice_len}."
+            );
+
+            detected_max_size = random_slice_len;
+        } else {
+            assert_eq!(
+                detected_max_size, random_slice_len,
+                "We should have received max size {detected_max_size}, but got {random_slice_len}.",
+            );
+        }
+    }
+}
+
+#[test]
+fn test_get_random_small_sizes() {
+    let (_sim_lifeline, mut tpm) = get_started_tpm();
+
+    for i in 0..1 {
+        let command = GetRandomCmd { bytes_requested: i };
+
+        let resp = run_command(&command, &mut tpm).expect("Failed running command.");
+
+        // Lets pull out the actual slice size for convenience
+        let random_slice_len = resp.random_bytes.as_ref().len();
+
+        assert_eq!(
+            random_slice_len, i as usize,
+            "We should have received {i}, but got {random_slice_len} bytes."
+        );
+    }
+}


### PR DESCRIPTION
- Add test crude test to catch entirely random data.
- Ordered tests into sub modules matching TPM command chapters.
- Fixes https://github.com/tpm-rs/tpm-rs/issues/118