### PR TITLE
server: Move buffers to separate modules

### DIFF
--- a/server/src/buffers/inout.rs
+++ b/server/src/buffers/inout.rs
@@ -1,0 +1,41 @@
+use crate::platform::{ReadOutOfBounds, TpmBuffers, TpmReadBuffer, TpmWriteBuffer};
+
+/// Abstraction that Represents a request and response that existing in the same mutable buffer.
+pub struct InOutBuffer<'a, W: ?Sized> {
+    buffer: &'a mut W,
+    // number of bytes that can be read from buffer
+    len: usize,
+}
+
+impl<'a, W: TpmWriteBuffer + ?Sized> InOutBuffer<'a, W> {
+    pub fn new(buffer: &'a mut W, request_size: usize) -> Self {
+        let len = request_size.min(buffer.len());
+        Self { buffer, len }
+    }
+}
+
+impl<'a, W: TpmWriteBuffer + ?Sized> TpmBuffers for InOutBuffer<'a, W> {
+    type Request = Self;
+    type Response = W;
+
+    fn get_request(&self) -> &Self::Request {
+        self
+    }
+    fn get_response(&mut self) -> &mut Self::Response {
+        self.buffer
+    }
+}
+
+impl<'a, W: TpmWriteBuffer + ?Sized> TpmReadBuffer for InOutBuffer<'a, W> {
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn read_into(&self, offset: usize, out: &mut [u8]) -> Result<(), ReadOutOfBounds> {
+        // Limit the read view to only the request portion of the in-place buffer
+        if self.len < offset + out.len() {
+            return Err(ReadOutOfBounds);
+        }
+        self.buffer.read_into(offset, out)
+    }
+}

--- a/server/src/buffers/mod.rs
+++ b/server/src/buffers/mod.rs
@@ -1,0 +1,5 @@
+mod inout;
+mod separate;
+
+pub use inout::InOutBuffer;
+pub use separate::SeparateBuffers;

--- a/server/src/buffers/separate.rs
+++ b/server/src/buffers/separate.rs
@@ -1,0 +1,33 @@
+use crate::platform::{TpmBuffers, TpmReadBuffer, TpmWriteBuffer};
+
+/// Abstraction layer that represents a separate request and response buffer.
+pub struct SeparateBuffers<'a, R: ?Sized, W: ?Sized> {
+    reader: &'a R,
+    writer: &'a mut W,
+}
+
+impl<'a, R, W> SeparateBuffers<'a, R, W>
+where
+    R: TpmReadBuffer + ?Sized,
+    W: TpmWriteBuffer + ?Sized,
+{
+    pub fn new(reader: &'a R, writer: &'a mut W) -> Self {
+        Self { reader, writer }
+    }
+}
+
+impl<'a, R, W> TpmBuffers for SeparateBuffers<'a, R, W>
+where
+    R: TpmReadBuffer + ?Sized,
+    W: TpmWriteBuffer + ?Sized,
+{
+    type Request = R;
+    type Response = W;
+
+    fn get_request(&self) -> &Self::Request {
+        self.reader
+    }
+    fn get_response(&mut self) -> &mut Self::Response {
+        self.writer
+    }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(test), no_std)]
 #![forbid(unsafe_code)]
 
+mod buffers;
 mod handler;
 pub mod platform;
 mod req_resp;


### PR DESCRIPTION
This patch moves all the separate buffers abstractions into separate files so TpmContext does not have to interact with their inner workings. We also move away from tuple based structs and use structs with named fields to improve readability. This patch modifies no business logic and adds no feature.