### PR TITLE
Remove a newline between doc comment and code.

### DIFF
--- a/client/src/sessions/password.rs
+++ b/client/src/sessions/password.rs
@@ -39,7 +39,6 @@ impl PasswordSession {
     ///     PasswordSession::new(&bad_password).err().unwrap(),
     ///     TpmRcError::Size
     /// );
-
     /// ```
     pub fn new<T: AsRef<[u8]> + ?Sized>(password: &T) -> TpmRcResult<Self> {
         Ok(PasswordSession {

--- a/marshalable-derive/src/lib.rs
+++ b/marshalable-derive/src/lib.rs
@@ -24,7 +24,6 @@ use syn::{
 ///    generated code will include a discriminant() implementation that returns
 ///    $primitive, try_{un}marshal routines that accept an external selector, and will
 ///    {un}marshal the discriminant in BE format prior to the variant.
-
 #[proc_macro_derive(Marshalable, attributes(marshalable))]
 pub fn derive_tpm_marshal(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/server/src/buffers/inout.rs
+++ b/server/src/buffers/inout.rs
@@ -14,7 +14,7 @@ impl<'a, W: TpmWriteBuffer + ?Sized> InOutBuffer<'a, W> {
     }
 }
 
-impl<'a, W: TpmWriteBuffer + ?Sized> TpmBuffers for InOutBuffer<'a, W> {
+impl<W: TpmWriteBuffer + ?Sized> TpmBuffers for InOutBuffer<'_, W> {
     type Request = Self;
     type Response = W;
 
@@ -26,7 +26,7 @@ impl<'a, W: TpmWriteBuffer + ?Sized> TpmBuffers for InOutBuffer<'a, W> {
     }
 }
 
-impl<'a, W: TpmWriteBuffer + ?Sized> TpmReadBuffer for InOutBuffer<'a, W> {
+impl<W: TpmWriteBuffer + ?Sized> TpmReadBuffer for InOutBuffer<'_, W> {
     fn len(&self) -> usize {
         self.len
     }

--- a/server/src/buffers/separate.rs
+++ b/server/src/buffers/separate.rs
@@ -16,7 +16,7 @@ where
     }
 }
 
-impl<'a, R, W> TpmBuffers for SeparateBuffers<'a, R, W>
+impl<R, W> TpmBuffers for SeparateBuffers<'_, R, W>
 where
     R: TpmReadBuffer + ?Sized,
     W: TpmWriteBuffer + ?Sized,

--- a/server/src/req_resp.rs
+++ b/server/src/req_resp.rs
@@ -48,7 +48,7 @@ pub struct Response<'a, B: TpmBuffers> {
     buffers: &'a mut RequestResponseCursor<B>,
 }
 
-impl<'a, B: TpmBuffers> Response<'a, B> {
+impl<B: TpmBuffers> Response<'_, B> {
     /// Writes the specified `data` at the last written location and updates the internal
     /// last written location. Returns [`WriteOutOfBounds`] if write would have written past the the
     /// of the underlying [`TpmWriteBuffer`].

--- a/unionify/src/lib.rs
+++ b/unionify/src/lib.rs
@@ -24,7 +24,6 @@ pub trait UnionSize {
 }
 
 #[cfg(test)]
-
 mod test {
     #[test]
     fn test_unionify() {


### PR DESCRIPTION
This was causing trouble for CI clippy checks (source: https://github.com/tpm-rs/tpm-rs/actions/runs/12285661194), it's been that way for a while, so I think we just missed it when enabling the clippy checks in CI.

I checked this using `cargo clippy --all-targets -- -D warnings` manually and got a good result.