### PR TITLE
Add `TpmsSchemeEcdaa` and fix definition of `TpmsSigSchemeEcdaa`

### DIFF
--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -993,6 +993,13 @@ pub struct TpmsSchemeHash {
     pub hash_alg: TpmiAlgHash,
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+pub struct TpmsSchemeEcdaa {
+    pub hash_alg: TpmiAlgHash,
+    pub count: u16,
+}
+
 pub type TpmsKeySchemeEcdh = TpmsSchemeHash;
 pub type TpmsKeySchemeEcmqv = TpmsSchemeHash;
 pub type TpmsSigSchemeRsassa = TpmsSchemeHash;
@@ -1000,7 +1007,7 @@ pub type TpmsSigSchemeRsapss = TpmsSchemeHash;
 pub type TpmsSigSchemeEcdsa = TpmsSchemeHash;
 pub type TpmsSigSchemeSm2 = TpmsSchemeHash;
 pub type TpmsSigSchemeEcschnorr = TpmsSchemeHash;
-pub type TpmsSigSchemeEcdaa = TpmsSchemeHash;
+pub type TpmsSigSchemeEcdaa = TpmsSchemeEcdaa;
 pub type TpmsEncSchemeOaep = TpmsSchemeHash;
 pub type TpmsEncSchemeRsaes = TpmsEmpty;
 


### PR DESCRIPTION
See sections 11.1.18 and 11.2.1.3 in https://trustedcomputinggroup.org/wp-content/uploads/TPM-2.0-1.83-Part-2-Structures.pdf. 

The note on section 11.2.1.4 says
> The TPMS_SIG_SCHEME_!ALG is determined by Table 169 or Table 170 and will be either a
TPMS_SCHEME_HASH or a TPMS_SCHEME_ECDAA.

TPMS_SIG_SCHEME_!ALG.AXN includes only TPM_ALG_ECDAA.
