### PR TITLE
Improve Tpm2b* and Tpm2bSimple traits.

### DIFF
--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -854,9 +854,8 @@ pub struct TpmsSensitiveCreate {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable, Tpm2bStruct)]
 #[marshalable(tpm2b_simple)]
-#[marshalable(tpm2b_struct)]
 pub struct Tpm2bSensitiveCreate {
     size: u16,
     sensitive: [u8; size_of::<TpmsSensitiveCreate>()],
@@ -1166,9 +1165,8 @@ impl Marshalable for TpmtPublic {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable, Tpm2bStruct)]
 #[marshalable(tpm2b_simple)]
-#[marshalable(tpm2b_struct)]
 pub struct Tpm2bPublic {
     size: u16,
     public_area: [u8; size_of::<TpmtPublic>()],
@@ -1457,9 +1455,8 @@ pub struct TpmsCreationData {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable, Tpm2bStruct)]
 #[marshalable(tpm2b_simple)]
-#[marshalable(tpm2b_struct)]
 pub struct Tpm2bCreationData {
     size: u16,
     creation_data: [u8; size_of::<TpmsCreationData>()],

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -589,7 +589,8 @@ enum TpmuName {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bDigest {
     size: u16,
     buffer: [u8; TpmtHa::UNION_SIZE],
@@ -599,42 +600,48 @@ pub type Tpm2bNonce = Tpm2bDigest;
 pub type Tpm2bOperand = Tpm2bDigest;
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bData {
     size: u16,
     buffer: [u8; TpmtHa::UNION_SIZE],
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bEvent {
     size: u16,
     buffer: [u8; 1024],
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bMaxBuffer {
     size: u16,
     buffer: [u8; TPM2_MAX_DIGEST_BUFFER as usize],
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bMaxNvBuffer {
     size: u16,
     buffer: [u8; TPM2_MAX_NV_BUFFER_SIZE as usize],
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bIv {
     size: u16,
     buffer: [u8; TPM2_MAX_SYM_BLOCK_SIZE as usize],
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bName {
     size: u16,
     name: [u8; TpmuName::UNION_SIZE],
@@ -786,21 +793,24 @@ impl Marshalable for TpmsAttest {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bAttest {
     size: u16,
     attestation_data: [u8; size_of::<TpmsAttest>()],
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bSymKey {
     size: u16,
     buffer: [u8; TPM2_MAX_SYM_KEY_BYTES as usize],
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bLabel {
     size: u16,
     buffer: [u8; TPM2_LABEL_MAX_BUFFER as usize],
@@ -827,7 +837,8 @@ enum TpmuSensitiveCreate {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bSensitiveData {
     size: u16,
     buffer: [u8; TpmuSensitiveCreate::UNION_SIZE],
@@ -843,28 +854,33 @@ pub struct TpmsSensitiveCreate {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
+#[marshalable(tpm2b_struct)]
 pub struct Tpm2bSensitiveCreate {
     size: u16,
     sensitive: [u8; size_of::<TpmsSensitiveCreate>()],
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bPublicKeyRsa {
     size: u16,
     buffer: [u8; TPM2_MAX_RSA_KEY_BYTES as usize],
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bPrivateKeyRsa {
     size: u16,
     buffer: [u8; (TPM2_MAX_RSA_KEY_BYTES / 2) as usize],
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bEccParameter {
     size: u16,
     buffer: [u8; TPM2_MAX_ECC_KEY_BYTES as usize],
@@ -894,7 +910,8 @@ enum TpmuEncryptedSecret {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bEncryptedSecret {
     size: u16,
     secret: [u8; TpmuEncryptedSecret::UNION_SIZE],
@@ -1149,21 +1166,25 @@ impl Marshalable for TpmtPublic {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
+#[marshalable(tpm2b_struct)]
 pub struct Tpm2bPublic {
     size: u16,
     public_area: [u8; size_of::<TpmtPublic>()],
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bTemplate {
     size: u16,
     buffer: [u8; size_of::<TpmtPublic>()],
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bPrivateVendorSpecific {
     size: u16,
     buffer: [u8; TPM2_PRIVATE_VENDOR_SPECIFIC_BYTES as usize],
@@ -1361,7 +1382,8 @@ pub struct _PRIVATE {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bPrivate {
     size: u16,
     buffer: [u8; size_of::<_PRIVATE>()],
@@ -1375,7 +1397,8 @@ pub struct TpmsIdObject {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bIdObject {
     size: u16,
     credential: [u8; size_of::<TpmsIdObject>()],
@@ -1399,7 +1422,8 @@ pub struct Tpm2bNvPublic {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bContextSensitive {
     size: u16,
     buffer: [u8; TPM2_MAX_CONTEXT_SIZE as usize],
@@ -1413,7 +1437,8 @@ pub struct TpmsContextData {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
 pub struct Tpm2bContextData {
     size: u16,
     buffer: [u8; size_of::<TpmsContextData>()],
@@ -1432,7 +1457,9 @@ pub struct TpmsCreationData {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+#[marshalable(tpm2b_simple)]
+#[marshalable(tpm2b_struct)]
 pub struct Tpm2bCreationData {
     size: u16,
     creation_data: [u8; size_of::<TpmsCreationData>()],
@@ -1449,111 +1476,6 @@ pub trait Tpm2bSimple {
         Self: Sized;
 }
 
-macro_rules! impl_try_marshalable_tpm2b_simple {
-    ($T:ty, $F:ident) => {
-        impl Tpm2bSimple for $T {
-            const MAX_BUFFER_SIZE: usize = size_of::<$T>() - size_of::<u16>();
-
-            fn get_size(&self) -> u16 {
-                self.size
-            }
-
-            fn get_buffer(&self) -> &[u8] {
-                &self.$F[0..self.get_size() as usize]
-            }
-
-            fn from_bytes(buffer: &[u8]) -> TpmRcResult<Self> {
-                // Overflow check
-                if buffer.len() > core::cmp::min(u16::MAX as usize, Self::MAX_BUFFER_SIZE) {
-                    return Err(TpmRcError::Size);
-                }
-
-                let mut dest: Self = Self {
-                    size: buffer.len() as u16,
-                    $F: [0; Self::MAX_BUFFER_SIZE],
-                };
-                dest.$F[..buffer.len()].copy_from_slice(buffer);
-                Ok(dest)
-            }
-        }
-
-        impl Default for $T {
-            fn default() -> Self {
-                Self {
-                    size: 0,
-                    $F: [0; Self::MAX_BUFFER_SIZE],
-                }
-            }
-        }
-
-        impl AsRef<[u8]> for $T {
-            fn as_ref(&self) -> &[u8] {
-                &self.$F[..self.size as usize]
-            }
-        }
-
-        impl Marshalable for $T {
-            fn try_unmarshal(buffer: &mut UnmarshalBuf) -> TpmRcResult<Self> {
-                let got_size = u16::try_unmarshal(buffer)?;
-                // Ensure the buffer is large enough to fullfill the size indicated
-                let sized_buffer = buffer.get(got_size as usize);
-                if !sized_buffer.is_some() {
-                    return Err(TpmRcError::Memory);
-                }
-
-                let mut dest: Self = Self {
-                    size: got_size,
-                    $F: [0; Self::MAX_BUFFER_SIZE],
-                };
-
-                // Make sure the size indicated isn't too large for the types buffer
-                if sized_buffer.unwrap().len() > dest.$F.len() {
-                    return Err(TpmRcError::Memory);
-                }
-                dest.$F[..got_size.into()].copy_from_slice(&sized_buffer.unwrap());
-
-                Ok(dest)
-            }
-
-            fn try_marshal(&self, buffer: &mut [u8]) -> TpmRcResult<usize> {
-                let used = self.size.try_marshal(buffer)?;
-                let (_, rest) = buffer.split_at_mut(used);
-                let buffer_marsh = self.get_size() as usize;
-                if buffer_marsh > (core::cmp::max(Self::MAX_BUFFER_SIZE, rest.len())) {
-                    return Err(TpmRcError::Memory);
-                }
-                rest[..buffer_marsh].copy_from_slice(&self.$F[..buffer_marsh]);
-                Ok(used + buffer_marsh)
-            }
-        }
-    };
-}
-
-impl_try_marshalable_tpm2b_simple! {Tpm2bName, name}
-impl_try_marshalable_tpm2b_simple! {Tpm2bAttest, attestation_data}
-impl_try_marshalable_tpm2b_simple! {Tpm2bContextData, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bContextSensitive, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bData, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bDigest, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bEccParameter, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bEncryptedSecret, secret}
-impl_try_marshalable_tpm2b_simple! {Tpm2bEvent, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bIdObject, credential}
-impl_try_marshalable_tpm2b_simple! {Tpm2bIv, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bMaxBuffer, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bMaxNvBuffer, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bPrivate, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bPrivateKeyRsa, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bPrivateVendorSpecific, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bPublicKeyRsa, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bSensitiveData, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bSymKey, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bTemplate, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bLabel, buffer}
-impl_try_marshalable_tpm2b_simple! {Tpm2bSensitiveCreate, sensitive}
-impl_try_marshalable_tpm2b_simple! {Tpm2bPublic, public_area}
-impl_try_marshalable_tpm2b_simple! {Tpm2bCreationData, creation_data}
-
 /// Provides conversion to/from a struct type for TPM2B types that don't hold a bytes buffer.
 pub trait Tpm2bStruct: Tpm2bSimple {
     type StructType: Marshalable;
@@ -1566,27 +1488,6 @@ pub trait Tpm2bStruct: Tpm2bSimple {
     /// Extracts the struct value from the 2b holder.
     fn to_struct(&self) -> TpmRcResult<Self::StructType>;
 }
-macro_rules! impl_try_marshalable_tpm2b_struct {
-    ($T:ty, $StructType:ty, $F:ident) => {
-        impl Tpm2bStruct for $T {
-            type StructType = $StructType;
-
-            fn from_struct(val: &Self::StructType) -> TpmRcResult<Self> {
-                let mut x = Self::default();
-                x.size = val.try_marshal(&mut x.$F)? as u16;
-                Ok(x)
-            }
-
-            fn to_struct(&self) -> TpmRcResult<Self::StructType> {
-                let mut buf = UnmarshalBuf::new(&self.$F[0..self.get_size() as usize]);
-                Self::StructType::try_unmarshal(&mut buf)
-            }
-        }
-    };
-}
-impl_try_marshalable_tpm2b_struct! {Tpm2bSensitiveCreate, TpmsSensitiveCreate, sensitive}
-impl_try_marshalable_tpm2b_struct! {Tpm2bPublic, TpmtPublic, public_area}
-impl_try_marshalable_tpm2b_struct! {Tpm2bCreationData, TpmsCreationData, creation_data}
 
 // Adds common helpers for TPML type $T.
 macro_rules! impl_tpml {

--- a/marshalable-derive/src/lib.rs
+++ b/marshalable-derive/src/lib.rs
@@ -1,12 +1,12 @@
 #![forbid(unsafe_code)]
 
-use std::collections::HashMap;
-
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned};
+use std::collections::HashMap;
 use syn::{
     parse_macro_input, spanned::Spanned, Attribute, Data, DataEnum, DeriveInput, Error, Expr,
-    Field, Fields, FieldsNamed, Ident, Index, MetaNameValue, Path, Result, Type,
+    ExprCall, ExprPath, Field, Fields, FieldsNamed, Ident, Index, MetaNameValue, Path,
+    PathArguments, Result, Type,
 };
 
 /// The Marshalable derive macro generates an implementation of the Marshalable trait
@@ -36,6 +36,14 @@ pub fn derive_tpm_marshal(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 fn derive_tpm_marshal_inner(input: DeriveInput) -> Result<TokenStream> {
     let input_span = input.span();
     let name = input.ident;
+    let has_tpm2b_simple = input
+        .attrs
+        .iter()
+        .any(|attr| has_marshalable_attr(attr, "tpm2b_simple"));
+    let has_tpm2b_struct = input
+        .attrs
+        .iter()
+        .any(|attr| has_marshalable_attr(attr, "tpm2b_struct"));
     let (marsh_text, unmarsh_text, pure_impl) = match input.data {
         Data::Struct(stru) => {
             let marshal_text = get_field_marshal_body(&stru.fields)?;
@@ -50,7 +58,14 @@ fn derive_tpm_marshal_inner(input: DeriveInput) -> Result<TokenStream> {
                 #field_unmarsh
                 Ok(#instantiation)
             };
-            (marshal_text, unmarshal_text, TokenStream::new())
+
+            let pure_impl = if has_tpm2b_simple || has_tpm2b_struct {
+                derive_tpm2b_code(&name, &stru, has_tpm2b_simple, has_tpm2b_struct)?
+            } else {
+                TokenStream::new()
+            };
+
+            (marshal_text, unmarshal_text, pure_impl)
         }
         Data::Enum(enu) => {
             let marshal_text = get_enum_marshal_impl();
@@ -65,23 +80,276 @@ fn derive_tpm_marshal_inner(input: DeriveInput) -> Result<TokenStream> {
             ));
         }
     };
-    let expanded = quote! {
-        #pure_impl
-        // The generated impl.
-        impl Marshalable for #name  {
-            fn try_unmarshal(buffer: &mut tpm2_rs_marshalable::UnmarshalBuf) -> tpm2_rs_marshalable::exports::errors::TpmRcResult<Self> {
-                #unmarsh_text
-            }
+    let expanded = if has_tpm2b_simple || has_tpm2b_struct {
+        quote! {
+            #pure_impl
+        }
+    } else {
+        quote! {
+            #pure_impl
+            // The generated impl.
+            impl Marshalable for #name  {
+                fn try_unmarshal(buffer: &mut tpm2_rs_marshalable::UnmarshalBuf) -> tpm2_rs_marshalable::exports::errors::TpmRcResult<Self> {
+                    #unmarsh_text
+                }
 
-            fn try_marshal(&self, buffer: &mut [u8]) -> tpm2_rs_marshalable::exports::errors::TpmRcResult<usize> {
-                let mut written: usize = 0;
-                #marsh_text;
-                Ok(written)
+                fn try_marshal(&self, buffer: &mut [u8]) -> tpm2_rs_marshalable::exports::errors::TpmRcResult<usize> {
+                    let mut written: usize = 0;
+                    #marsh_text;
+                    Ok(written)
+                }
             }
         }
     };
-
     Ok(expanded)
+}
+
+fn derive_tpm2b_code(
+    tpm2b_outer_struct_name: &Ident,
+    stru: &syn::DataStruct,
+    tpm2b_simple: bool,
+    tpm2b_struct: bool,
+) -> Result<TokenStream> {
+    const TPM2B_SIMPLE_ERR_GENERAL: &str = "A Tpm2b struct must contain just two elements, a u16 size and a buffer array when using #[marshalable(tpm2b_simple)]";
+    const TPM2B_SIMPLE_ERR_1ST_ELM: &str = "First element in Tpm2b struct must be a 'size: u16' when using #[marshalable(tpm2b_simple)]";
+    const TPM2B_SIMPLE_ERR_2ND_ELM: &str = "Second element in Tpm2b struct must be u8 buffer: <buffer name>: [u8, <buffer size>] when using #[marshalable(tpm2b_simple)].";
+    const TPM2B_STRUCT_ERR_2ND_ELM: &str = "Second element in Tpm2b struct must define a u8 buffer using sizeof expression: <buffer name>: [u8, sizeof( <some struct>) ] when using #[marshalable(tpm2b_struct)].";
+
+    // Note: At least one of "tpm2b_simple" and "tpm2b_struct" is true.
+    if !tpm2b_simple {
+        return Err(Error::new(
+            tpm2b_outer_struct_name.span(),
+            "We can't have #[marshalable(tpm2b_struct)] without #[marshalable(tpm2b_simple)]",
+        ));
+    }
+
+    if let Fields::Named(ref fields) = stru.fields {
+        // First make sure we have precisely 2 elements:
+        if fields.named.len() != 2 {
+            return Err(Error::new(fields.named.span(), TPM2B_SIMPLE_ERR_GENERAL));
+        }
+
+        // Lets validate the first element is named size and has type u16.
+        {
+            let first = &fields.named[0];
+            let field_name = first.ident.as_ref().unwrap();
+            let field_type = &first.ty;
+            if field_name != "size"
+                || !matches!(
+                    field_type,
+                    syn::Type::Path(type_path) if type_path.path.is_ident("u16")
+                )
+            {
+                return Err(Error::new(field_name.span(), TPM2B_SIMPLE_ERR_1ST_ELM));
+            }
+        };
+
+        // Lets validate the second element in the Tpm2b structure and extract name and size expression.
+        let second = &fields.named[1];
+        let field_name = second.ident.as_ref().unwrap();
+        let field_type = &second.ty;
+
+        // Expect array type.
+        let type_array = if let syn::Type::Array(type_array) = field_type {
+            type_array
+        } else {
+            return Err(Error::new(field_type.span(), TPM2B_SIMPLE_ERR_2ND_ELM));
+        };
+
+        // Extract the type used.
+        let type_path = if let syn::Type::Path(type_path) = &*type_array.elem {
+            type_path
+        } else {
+            return Err(Error::new(type_array.elem.span(), TPM2B_SIMPLE_ERR_2ND_ELM));
+        };
+
+        // Confirm it is an array of u8 elements.
+        if !type_path.path.is_ident("u8") {
+            return Err(Error::new(type_array.elem.span(), TPM2B_SIMPLE_ERR_2ND_ELM));
+        };
+
+        // Lets extract the size expression.
+        let size_expression = &type_array.len;
+
+        // Lets extract the <some struct> name from tpm2b buffer definition <buffer name>: [u8, sizeof( <some struct>) ]
+        let tpm2b_inner_struct_name = if tpm2b_struct {
+            // Extract the func, args.
+            let func = if let Expr::Call(ExprCall { func, .. }) = size_expression {
+                func
+            } else {
+                return Err(Error::new(size_expression.span(), TPM2B_SIMPLE_ERR_2ND_ELM));
+            };
+
+            // Check if the function being called is "sizeof"
+            let tpm2b_inner_struct_name = if let Expr::Path(ExprPath { path, .. }) = &**func {
+                // The path contains multiple elements, the first must be sizeof.
+                let segment = path.segments.first().expect(TPM2B_STRUCT_ERR_2ND_ELM);
+                if segment.ident != "size_of" {
+                    return Err(Error::new(path.segments.span(), TPM2B_SIMPLE_ERR_2ND_ELM));
+                };
+                let arguments =
+                    if let PathArguments::AngleBracketed(sizeof_args) = &segment.arguments {
+                        sizeof_args
+                    } else {
+                        return Err(Error::new(
+                            segment.arguments.span(),
+                            TPM2B_SIMPLE_ERR_2ND_ELM,
+                        ));
+                    };
+
+                let struct_type = arguments.args.first().expect(TPM2B_STRUCT_ERR_2ND_ELM);
+
+                let struct_path =
+                    if let syn::GenericArgument::Type(syn::Type::Path(type_path)) = struct_type {
+                        type_path
+                    } else {
+                        return Err(Error::new(struct_type.span(), TPM2B_SIMPLE_ERR_2ND_ELM));
+                    };
+
+                let struct_ident = struct_path
+                    .path
+                    .segments
+                    .first()
+                    .expect(TPM2B_STRUCT_ERR_2ND_ELM);
+                struct_ident
+            } else {
+                return Err(Error::new(func.span(), TPM2B_SIMPLE_ERR_2ND_ELM));
+            };
+            Some(&tpm2b_inner_struct_name.ident)
+        } else {
+            None
+        };
+
+        // First generate the actual code for structs marked with #[marshalable(tpm2b_simple)].
+        let tpm2b_simple_code = quote! {
+            // The generated impl.
+            impl Tpm2bSimple for #tpm2b_outer_struct_name {
+                const MAX_BUFFER_SIZE: usize = #size_expression;
+
+                fn get_size(&self) -> u16 {
+                    self.size
+                }
+
+                fn get_buffer(&self) -> &[u8] {
+                    &self.#field_name[0..self.get_size() as usize]
+                }
+
+                fn from_bytes(buffer: &[u8]) -> TpmRcResult<Self> {
+                    // Overflow check
+                    if buffer.len() > core::cmp::min(u16::MAX as usize, Self::MAX_BUFFER_SIZE) {
+                        return Err(TpmRcError::Size);
+                    }
+
+                    let mut dest: Self = Self {
+                        size: buffer.len() as u16,
+                        #field_name: [0; Self::MAX_BUFFER_SIZE],
+                    };
+                    dest.#field_name[..buffer.len()].copy_from_slice(buffer);
+                    Ok(dest)
+                }
+            }
+            impl Default for #tpm2b_outer_struct_name {
+                fn default() -> Self {
+                    Self {
+                        size: 0,
+                        #field_name: [0; Self::MAX_BUFFER_SIZE],
+                    }
+                }
+            }
+
+            impl AsRef<[u8]> for #tpm2b_outer_struct_name {
+                fn as_ref(&self) -> &[u8] {
+                    &self.#field_name[..self.size as usize]
+                }
+            }
+
+            impl Marshalable for #tpm2b_outer_struct_name {
+                fn try_unmarshal(buffer: &mut UnmarshalBuf) -> TpmRcResult<Self> {
+                    let got_size = u16::try_unmarshal(buffer)?;
+                    // Ensure the buffer is large enough to fullfill the size indicated
+                    let sized_buffer = buffer.get(got_size as usize);
+                    if !sized_buffer.is_some() {
+                        return Err(TpmRcError::Memory);
+                    }
+
+                    let mut dest: Self = Self {
+                        size: got_size,
+                        #field_name: [0; Self::MAX_BUFFER_SIZE],
+                    };
+
+                    // Make sure the size indicated isn't too large for the types buffer
+                    if sized_buffer.unwrap().len() > dest.#field_name.len() {
+                        return Err(TpmRcError::Memory);
+                    }
+                    dest.#field_name[..got_size.into()].copy_from_slice(&sized_buffer.unwrap());
+
+                    Ok(dest)
+                }
+
+                fn try_marshal(&self, buffer: &mut [u8]) -> TpmRcResult<usize> {
+                    let used = self.size.try_marshal(buffer)?;
+                    let (_, rest) = buffer.split_at_mut(used);
+                    let buffer_marsh = self.get_size() as usize;
+                    if buffer_marsh > (core::cmp::max(Self::MAX_BUFFER_SIZE, rest.len())) {
+                        return Err(TpmRcError::Memory);
+                    }
+                    rest[..buffer_marsh].copy_from_slice(&self.#field_name[..buffer_marsh]);
+                    Ok(used + buffer_marsh)
+                }
+            }
+        };
+
+        let tpm2b_struct_code = if tpm2b_inner_struct_name.is_some() {
+            quote! {
+                impl Tpm2bStruct for #tpm2b_outer_struct_name {
+                    type StructType = #tpm2b_inner_struct_name;
+
+                    fn from_struct(val: &Self::StructType) -> TpmRcResult<Self> {
+                        let mut x = Self::default();
+                        x.size = val.try_marshal(&mut x.#field_name)? as u16;
+                        Ok(x)
+                    }
+
+                    fn to_struct(&self) -> TpmRcResult<Self::StructType> {
+                        let mut buf = UnmarshalBuf::new(&self.#field_name[0..self.get_size() as usize]);
+                        Self::StructType::try_unmarshal(&mut buf)
+                    }
+                }
+            }
+        } else {
+            quote! {}
+        };
+        Ok(quote! { #tpm2b_simple_code #tpm2b_struct_code })
+    } else {
+        Err(Error::new(
+            tpm2b_outer_struct_name.span(),
+            TPM2B_SIMPLE_ERR_GENERAL,
+        ))
+    }
+}
+
+fn has_marshalable_attr(attr: &Attribute, attribute: &str) -> bool {
+    // Ensure the attribute path matches "Marshalable"
+    if attr.path().is_ident("marshalable") {
+        // Parse the arguments of the attribute
+        attr.parse_args_with(|input: syn::parse::ParseStream| {
+            // Look for the attribute given as input.
+            while !input.is_empty() {
+                let path: syn::Path = input.parse()?;
+                if path.is_ident(attribute) {
+                    return Ok(true);
+                }
+                // Skip over commas (if present) between arguments
+                if input.peek(syn::Token![,]) {
+                    let _comma: syn::Token![,] = input.parse()?;
+                }
+            }
+            Ok(false)
+        })
+        .unwrap_or(false)
+    } else {
+        false
+    }
 }
 
 /// Produces a variant {un}marshal implementations for an enum.

--- a/marshalable/src/lib.rs
+++ b/marshalable/src/lib.rs
@@ -5,6 +5,7 @@ use safe_discriminant::Discriminant;
 
 use tpm2_rs_errors::*;
 pub use tpm2_rs_marshalable_derive::Marshalable;
+pub use tpm2_rs_marshalable_derive::Tpm2bStruct;
 
 /// Exports needed for macro expansion
 pub mod exports {


### PR DESCRIPTION
- Replace "impl_try_marshalable_tpm2b_simple" with derive attribute #[marshalable(tpm2b_simple)].
- Replace "impl_try_marshalable_tpm2b_struct" with #[derive(Tpm2bStruct)].
- Fixes https://github.com/tpm-rs/tpm-rs/issues/114.