### PR TITLE
Remove unstable features by default.

### DIFF
--- a/client/src/sessions/nosession.rs
+++ b/client/src/sessions/nosession.rs
@@ -5,10 +5,7 @@ use tpm2_rs_base::{errors::TssResult, TpmsAuthCommand, TpmsAuthResponse};
 /// making it unsuitable for use as a session. Its primary purpose is to serve
 /// as a placeholder type for the `AuthorizationArea*` traits whenever
 /// necessary.
-pub struct NoSession {
-    #[expect(dead_code, reason = "This prevents having NotSession instances")]
-    inaccessible: (),
-}
+pub enum NoSession {}
 
 impl Session for NoSession {
     fn validate_auth_response(&self, _: &TpmsAuthResponse) -> TssResult<()> {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2021"
 [dependencies]
 hex-literal = { workspace = true }
 tpm2-rs-base = { workspace = true }
+
+[features]
+default = []
+unstable = []

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -1,5 +1,4 @@
 use core::{
-    error::Error,
     fmt::{Debug, Display},
 };
 
@@ -15,5 +14,3 @@ impl Display for ServerError {
         }
     }
 }
-
-impl Error for ServerError {}

--- a/server/src/req_resp.rs
+++ b/server/src/req_resp.rs
@@ -52,10 +52,10 @@ impl<B: TpmBuffers> Response<'_, B> {
     /// Writes the specified `data` at the last written location and updates the internal
     /// last written location. Returns [`WriteOutOfBounds`] if write would have written past the the
     /// of the underlying [`TpmWriteBuffer`].
-    #[expect(
-        dead_code,
-        reason = "This function may be used later in the future, but it is not yet"
-    )]
+    #[cfg_attr(unstable, expect(
+	dead_code,
+	reason = "This function may be used later in the future, but it is not yet"))]
+    #[cfg_attr(not(unstable), allow(dead_code))]
     pub fn write(&mut self, data: &[u8]) -> Result<(), WriteOutOfBounds> {
         self.buffers
             .buffers


### PR DESCRIPTION
The #[expect] attribute is experimental and error_in_core is unstable. To make this crate usable from users of stable Rust, these changes are necessary.

The dead code expectation for NoSession was unnecessary, since an inaccessible type is an empty enum (no way to construct one).