### PR TITLE
no_std support

### DIFF
--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -5,6 +5,7 @@
 use crate::{constants::*, errors::*, marshal::*};
 use bitflags::bitflags;
 use core::cmp::min;
+use core::convert::{From, TryFrom};
 use core::mem::size_of;
 use open_enum::open_enum;
 use safe_discriminant::Discriminant;

--- a/errors/src/lib.rs
+++ b/errors/src/lib.rs
@@ -1,7 +1,9 @@
 #![forbid(unsafe_code)]
+#![cfg_attr(not(test), no_std)]
 
+use core::convert::TryFrom;
 use core::num::NonZeroU32;
-
+use core::result::{Result, Result::*};
 pub use tpm_rc::*;
 pub use tss_rc::*;
 

--- a/errors/src/tpm_rc/mod.rs
+++ b/errors/src/tpm_rc/mod.rs
@@ -1,4 +1,6 @@
 use core::num::NonZeroU32;
+use core::option::{Option, Option::*};
+use core::result::Result;
 
 /// Represents success or [`TpmRcError`] failure.
 pub type TpmRcResult<T> = Result<T, TpmRcError>;

--- a/errors/src/tss_rc.rs
+++ b/errors/src/tss_rc.rs
@@ -1,4 +1,7 @@
+use core::convert::From;
 use core::num::NonZeroU32;
+use core::option::Option::*;
+use core::result::Result;
 
 /// Generate a typed error and result for a specifc TSS client layer.
 macro_rules! generate_tss_layer_error {

--- a/marshalable/src/lib.rs
+++ b/marshalable/src/lib.rs
@@ -1,6 +1,9 @@
 #![forbid(unsafe_code)]
+#![cfg_attr(not(test), no_std)]
 
 use core::mem::size_of;
+use core::option::{Option, Option::*};
+use core::result::Result::*;
 use safe_discriminant::Discriminant;
 
 use tpm2_rs_errors::*;

--- a/unionify/src/lib.rs
+++ b/unionify/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), no_std)]
 //! [UnionSize] is a derivable trait that calculates the size of
 //! `repr(C)` union part in a tagged or untagged enum.
 //!


### PR DESCRIPTION
The added `use` statements are to account for a differences in prelude.