### PR TITLE
Add drbg crate with Hash DRBG parameters trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "base",
     "client",
+    "drbg",
     "errors",
     "marshalable",
     "marshalable-derive",
@@ -14,6 +15,7 @@ members = [
 [workspace.dependencies]
 # Third party dependencies
 bitflags = "2.4.2"
+digest = "0.10.7"
 hex-literal = { version = "0.4.1" }
 open-enum = "0.4.1"
 proc-macro2 = "1"
@@ -26,6 +28,7 @@ zerocopy = { version = "0.7.0", features = ["derive"] }
 # Common workspace crates
 tpm2-rs-base = { path = "base" }
 tpm2-rs-client = { path = "client" }
+tpm2-rs-drbg = { path = "drbg" }
 tpm2-rs-errors = { path = "errors" }
 tpm2-rs-marshalable = { path = "marshalable" }
 tpm2-rs-marshalable-derive = { path = "marshalable-derive" }

--- a/drbg/Cargo.toml
+++ b/drbg/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tpm2-rs-drbg"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+digest = { workspace = true }

--- a/drbg/src/lib.rs
+++ b/drbg/src/lib.rs
@@ -1,0 +1,9 @@
+#![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_code)]
+//! A Deterministic Random Bit Generator(DRBG) mechanism based
+//! on Hash Functions. Unless otherwise specified, references to section
+//! come directly from
+//! [NIST.SP.800-90Ar1](http://dx.doi.org/10.6028/NIST.SP.800-90Ar1).
+
+mod props;
+pub use props::{bits_to_bytes, HashDrbgProps};

--- a/drbg/src/props.rs
+++ b/drbg/src/props.rs
@@ -1,0 +1,78 @@
+use digest::{generic_array::ArrayLength, Digest};
+
+/// Divides by 8, rounding up
+///
+/// A utility function that calculates the minimum number of bytes required to
+/// store given bits.
+pub const fn bits_to_bytes(bits: usize) -> usize {
+    bits.div_ceil(8)
+}
+
+/// Constants for Hash-Based DRBG Mechanisms.
+pub trait HashDrbgProps: Digest {
+    /// Table 2: `outlen`
+    type OutLenBits: ArrayLength<u8>;
+    /// Table 2: `outlen` in Bytes
+    type OutLenBytes: ArrayLength<u8>;
+
+    /// Length of Expected Entropy.
+    /// According to Table 2, must be between `security_strength` and 2**35 bits.
+    type EntropyLenBytes: ArrayLength<u8>;
+
+    /// Table 2: Seed length (seedlen) for Hash_DRBG in bits
+    type SeedLenBits: ArrayLength<u8>;
+    /// Table 2: Seed length (seedlen) for Hash_DRBG converted to bytes
+    type SeedLenBytes: ArrayLength<u8>;
+
+    /// Table 2: `max_personalization_string_length`
+    const MAX_PERSONALIZATION_STRING_BITS: usize = usize::pow(2, 35);
+    /// Table 2: `max_personalization_string_length` in bytes
+    const MAX_PERSONALIZATION_STRING_BYTES: usize =
+        bits_to_bytes(Self::MAX_PERSONALIZATION_STRING_BITS);
+
+    /// Table 2: `max_additional_input_length`
+    const MAX_ADDITIONAL_INPUT_BITS: usize = usize::pow(2, 35);
+    /// Table 2: `max_additional_input_length` in bytes
+    const MAX_ADDITIONAL_INPUT_BYTES: usize = bits_to_bytes(Self::MAX_ADDITIONAL_INPUT_BITS);
+
+    /// Table 2: `max_number_of_bits_per_request`
+    const MAX_BITS_PER_REQUEST: usize = usize::pow(2, 19);
+    /// Table 2: `max_number_of_bits_per_request` in bytes
+    const MAX_BYTES_PER_REQUEST: usize = bits_to_bytes(Self::MAX_BITS_PER_REQUEST);
+
+    /// Table 2: `reseed_interval`
+    const MAX_REQUESTS_BETWEEN_RESEEDS: u64 = u64::pow(2, 48);
+
+    /// This implementation Requires a nonce.
+    ///
+    /// 8.6.7: A nonce may be required in the construction of a seed during instantiation in order
+    /// to provide a security cushion to block certain attacks.
+    type NonceLenBytes: ArrayLength<u8>;
+}
+
+#[cfg(test)]
+mod test {
+    use super::bits_to_bytes;
+
+    #[test]
+    fn test_bits_to_bytese() {
+        assert_eq!(bits_to_bytes(0), 0);
+        assert_eq!(bits_to_bytes(1), 1);
+        assert_eq!(bits_to_bytes(2), 1);
+        assert_eq!(bits_to_bytes(3), 1);
+        assert_eq!(bits_to_bytes(4), 1);
+        assert_eq!(bits_to_bytes(5), 1);
+        assert_eq!(bits_to_bytes(6), 1);
+        assert_eq!(bits_to_bytes(7), 1);
+        assert_eq!(bits_to_bytes(8), 1);
+        assert_eq!(bits_to_bytes(9), 2);
+        assert_eq!(bits_to_bytes(10), 2);
+        assert_eq!(bits_to_bytes(11), 2);
+        assert_eq!(bits_to_bytes(12), 2);
+        assert_eq!(bits_to_bytes(13), 2);
+        assert_eq!(bits_to_bytes(14), 2);
+        assert_eq!(bits_to_bytes(15), 2);
+        assert_eq!(bits_to_bytes(16), 2);
+        assert_eq!(bits_to_bytes(17), 3);
+    }
+}


### PR DESCRIPTION
This patch adds a new crate, `tpm2-rs-drbg`, to the workspace. It defines the `HashDrbgProps` trait with associated constants based on NIST SP 800-90A rev. 1. This is in an effort to chunk down  #146.



Let try it agian this time, I cannot promise putting much time, but hopefully this time it works out