### PR TITLE
feat: Add support for `TPM2_StartAuthSession` and `TPM2_CreatePrimary`

### DIFF
--- a/base/src/commands/hierarchy.rs
+++ b/base/src/commands/hierarchy.rs
@@ -1,7 +1,41 @@
 //! [TPM2.0 1.83] 24 Hierarchy Commands
 
+use crate::commands::{Marshalable, TpmCommand};
+use crate::constants::{TpmCc, TpmHandle};
+use crate::{
+    Tpm2bCreationData, Tpm2bData, Tpm2bDigest, Tpm2bName, Tpm2bPublic, Tpm2bSensitiveCreate,
+    TpmiRhHierarchy, TpmlPcrSelection, TpmtTkCreation,
+};
+
 /// [TPM2.0 1.83] 24.1 TPM2_CreatePrimary (Command)
-pub struct CreatePrimaryCmd {}
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Marshalable)]
+pub struct CreatePrimaryCmd {
+    pub in_sensitive: Tpm2bSensitiveCreate,
+    pub in_public: Tpm2bPublic,
+    pub outside_info: Tpm2bData,
+    pub creation_pcr: TpmlPcrSelection,
+}
+
+impl TpmCommand for CreatePrimaryCmd {
+    const CMD_CODE: TpmCc = TpmCc::CreatePrimary;
+
+    type Handles = TpmiRhHierarchy;
+    type RespT = CreatePrimaryResp;
+    // Object handle of type TPM_HT_TRANSIENT.
+    type RespHandles = TpmHandle;
+}
+
+/// [TPM2.0 1.83] 24.1 TPM2_CreatePrimary (Response)
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+pub struct CreatePrimaryResp {
+    pub out_public: Tpm2bPublic,
+    pub creation_data: Tpm2bCreationData,
+    pub creation_hash: Tpm2bDigest,
+    pub creation_ticket: TpmtTkCreation,
+    pub name: Tpm2bName,
+}
 
 /// [TPM2.0 1.83] 24.2 TPM2_HierarchyControl (Command)
 pub struct HierarchyControlCmd {}

--- a/base/src/commands/session.rs
+++ b/base/src/commands/session.rs
@@ -1,7 +1,43 @@
 //! [TPM2.0 1.83] 11 Session Commands
 
+use crate::commands::{Marshalable, TpmCommand};
+use crate::constants::{TpmCc, TpmSe};
+use crate::{
+    Tpm2bEncryptedSecret, Tpm2bNonce, TpmiAlgHash, TpmiDhEntity, TpmiDhObject, TpmiShAuthSession,
+    TpmtSymDefObject,
+};
+
 /// [TPM2.0 1.83] 11.1 TPM2_StartAuthSession (Command)
-pub struct StartAuthSessionCmd {}
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Marshalable)]
+pub struct StartAuthSessionCmd {
+    pub nonce_caller: Tpm2bNonce,
+    pub encrypted_salt: Tpm2bEncryptedSecret,
+    pub session_type: TpmSe,
+    pub symmetric: TpmtSymDefObject,
+    pub auth_hash: TpmiAlgHash,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default, PartialEq, Marshalable)]
+pub struct StartAuthSessionHandles {
+    pub tpm_key: TpmiDhObject,
+    pub bind: TpmiDhEntity,
+}
+
+impl TpmCommand for StartAuthSessionCmd {
+    const CMD_CODE: TpmCc = TpmCc::StartAuthSession;
+
+    type Handles = StartAuthSessionHandles;
+    type RespT = StartAuthSessionResp;
+    type RespHandles = TpmiShAuthSession;
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Marshalable)]
+pub struct StartAuthSessionResp {
+    pub nonce_tpm: Tpm2bNonce,
+}
 
 /// [TPM2.0 1.83] 11.2 TPM2_PolicyRestart (Command)
 pub struct PolicyRestartCmd {}

--- a/base/src/constants.rs
+++ b/base/src/constants.rs
@@ -398,6 +398,7 @@ pub enum TpmSu {
 // See definition in Part 2: Structures, section 6.11.
 #[open_enum]
 #[repr(u8)]
+#[derive(Copy, Clone, Default, Marshalable)]
 pub enum TpmSe {
     HMAC = 0x00,
     Policy = 0x01,
@@ -651,6 +652,8 @@ pub enum TpmPtPcr {
 // See definition in Part 2: Structures, section 7.2.
 #[open_enum]
 #[repr(u8)]
+#[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
+#[derive(Copy, Clone, Default, Marshalable)]
 pub enum TpmHt {
     PCR = 0x00,
     NVIndex = 0x01,
@@ -671,6 +674,7 @@ pub enum TpmHt {
 pub enum TpmHandle {
     RHOwner = 0x40000001,
     RHNull = 0x40000007,
+    RHUnassigned = 0x40000008,
     RSPW = 0x40000009,
     RHLockout = 0x4000000A,
     RHEndorsement = 0x4000000B,

--- a/base/src/constants.rs
+++ b/base/src/constants.rs
@@ -733,6 +733,14 @@ impl TpmHc {
     pub fn is_policy_session(value: u32) -> bool {
         (TpmHc::PolicySessionFirst.0..=TpmHc::PolicySessionLast.0).contains(&value)
     }
+    // The first transient object.
+    pub const TransientFirst: TpmHc = TpmHc::HRTransient;
+    // The last transient object.
+    pub const TransientLast: TpmHc = TpmHc(TpmHc::HRTransient.0 + 0x00FFFFFF);
+    /// Returns true if the value is a valid transient object handle.
+    pub fn is_transient_object(value: u32) -> bool {
+        (TpmHc::TransientFirst.0..=TpmHc::TransientLast.0).contains(&value)
+    }
     /// The first persistent object.
     pub const PersistentFirst: TpmHc = TpmHc::HRPersistent;
     /// The last persistent object.

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -337,6 +337,19 @@ impl TpmiShAuthSession {
     pub const RS_PW: TpmiShAuthSession = TpmiShAuthSession(TpmHandle::RSPW.0);
 }
 
+/// TpmiRhHierarchy represents a hierarchy selector.
+/// See definition in Part 2: Structures, section 9.13
+#[open_enum]
+#[repr(u32)]
+#[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
+#[derive(Copy, Clone, PartialEq, Default, Marshalable)]
+pub enum TpmiRhHierarchy {
+    TpmRhOwner = TpmHandle::RHOwner.0,
+    TpmRhPlatform = TpmHandle::RHPlatform.0,
+    TpmRhEndorsement = TpmHandle::RHEndorsement.0,
+    TpmRhNull = TpmHandle::RHNull.0,
+}
+
 /// TpmiEccCurve represents an implemented ECC curve (TPMI_ECC_SCHEME).
 /// See definition in Part 2: Structures, section 11.2.5.5.
 #[repr(transparent)]
@@ -352,6 +365,34 @@ pub struct TpmiEccCurve(TpmEccCurve);
 pub enum TpmiYesNo {
     NO = 0,
     YES = 1,
+}
+
+/// TpmiDhObject represents a handle that references a loaded object.
+/// See definition in Part 2: Structures, section 9.3.
+#[open_enum]
+#[repr(u32)]
+#[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
+#[derive(Copy, Clone, PartialEq, Default, Marshalable)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum TpmiDhObject {
+    RHNull = TpmHandle::RHNull.0,
+}
+
+/// TpmiDhEntity represents TPM-defined values that indicate that a handle
+/// refers to an _authValue_. The range of these values would change according
+/// to the TPM implementation.
+/// See definition in Part 2: Structures, section 9.6.
+#[open_enum]
+#[repr(u32)]
+#[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
+#[derive(Copy, Clone, PartialEq, Default, Marshalable)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum TpmiDhEntity {
+    RHOwner = TpmHandle::RHOwner.0,
+    RHEndorsement = TpmHandle::RHEndorsement.0,
+    RHPlatform = TpmHandle::RHPlatform.0,
+    RHLockout = TpmHandle::RHLockout.0,
+    RHNull = TpmHandle::RHNull.0,
 }
 
 /// TpmiStAttest represents an attestation structure type (TPMI_ST_ATTEST).

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -648,6 +648,7 @@ enum TpmuName {
 #[marshalable(tpm2b_simple)]
 pub struct Tpm2bDigest {
     size: u16,
+    #[marshalable(length=size)]
     buffer: [u8; TpmtHa::UNION_SIZE],
 }
 
@@ -659,6 +660,7 @@ pub type Tpm2bOperand = Tpm2bDigest;
 #[marshalable(tpm2b_simple)]
 pub struct Tpm2bData {
     size: u16,
+    #[marshalable(length=size)]
     buffer: [u8; TpmtHa::UNION_SIZE],
 }
 
@@ -699,6 +701,7 @@ pub struct Tpm2bIv {
 #[marshalable(tpm2b_simple)]
 pub struct Tpm2bName {
     size: u16,
+    #[marshalable(length=size)]
     name: [u8; TpmuName::UNION_SIZE],
 }
 
@@ -1224,6 +1227,7 @@ impl Marshalable for TpmtPublic {
 #[marshalable(tpm2b_simple)]
 pub struct Tpm2bPublic {
     size: u16,
+    #[marshalable(length=size)]
     public_area: [u8; size_of::<TpmtPublic>()],
 }
 
@@ -1525,6 +1529,7 @@ pub struct TpmtTkCreation {
 #[marshalable(tpm2b_simple)]
 pub struct Tpm2bCreationData {
     size: u16,
+    #[marshalable(length=size)]
     creation_data: [u8; size_of::<TpmsCreationData>()],
 }
 

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -413,9 +413,16 @@ pub enum TpmiStAttest {
 }
 
 /// The number of bits in an AES key.
-#[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, Marshalable)]
-pub struct TpmiAesKeyBits(u16);
+#[open_enum]
+#[repr(u16)]
+#[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
+#[derive(Copy, Clone, PartialEq, Default, Marshalable)]
+pub enum TpmiAesKeyBits {
+    Aes128 = 128,
+    Aes192 = 192,
+    Aes256 = 256,
+}
+
 /// The number of bits in an SM4 key.
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshalable)]
@@ -425,9 +432,15 @@ pub struct TpmiSm4KeyBits(u16);
 #[derive(Clone, Copy, PartialEq, Debug, Default, Marshalable)]
 pub struct TpmiCamelliaKeyBits(u16);
 /// The number of bits in an RSA key.
-#[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Debug, Default, Marshalable)]
-pub struct TpmiRsaKeyBits(u16);
+#[open_enum]
+#[repr(u16)]
+#[rustfmt::skip] #[derive(Debug)] // Keep debug derivation separate for open_enum override.
+#[derive(Copy, Clone, PartialEq, Default, Marshalable)]
+pub enum TpmiRsaKeyBits {
+    Rsa1024 = 1_024,
+    Rsa2048 = 2_048,
+    Rsa3072 = 3_072,
+}
 
 /// TpmaObject indicates an object's use, authorization types, and relationship to other objects (TPMA_OBJECT).
 /// See definition in Part 2: Structures, section 8.3.

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -1496,6 +1496,17 @@ pub struct TpmsCreationData {
     pub outside_info: Tpm2bData,
 }
 
+/// TpmtTkCreation represents a ticket produced by `TPM2_Create()` or
+/// `TPM2_CreatePrimary`, used to bind the created data to the object it's
+/// applied to. See definition in Part 2: Structures, section 10.7.3.
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Debug, Marshalable)]
+pub struct TpmtTkCreation {
+    pub tag: TpmSt,
+    pub hierarchy: TpmiRhHierarchy,
+    pub digest: Tpm2bDigest,
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug, Marshalable, Tpm2bStruct)]
 #[marshalable(tpm2b_simple)]

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -959,7 +959,7 @@ pub struct Tpm2bEccPoint {
 
 #[derive(UnionSize)]
 #[repr(C, u16)]
-enum TpmuEncryptedSecret {
+pub enum TpmuEncryptedSecret {
     Ecc([u8; size_of::<TpmsEccPoint>()]),
     Rsa([u8; constants::TPM2_MAX_RSA_KEY_BYTES as usize]),
     Symmetric([u8; size_of::<Tpm2bDigest>()]),

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -32,7 +32,7 @@ pub struct CmdHeader {
     code: TpmCc,
 }
 impl CmdHeader {
-    fn new(has_sessions: bool, code: TpmCc) -> CmdHeader {
+    pub fn new(has_sessions: bool, code: TpmCc) -> CmdHeader {
         let tag = if has_sessions {
             TpmiStCommandTag::NoSessions
         } else {


### PR DESCRIPTION
Hi, great library - as good as you can make it while having to deal with constant/bitmask hell 😅

This PR adds the necessary types required to interact with the `TPM2_StartAuthSession()` and `TPM2_CreatePrimary()` functions, tested successfully on my AMD TPM. Those changes remain basic and minimal, as-in there's still a lot of heavy lifting one has to do in determining the appropriate parameters, computing HMAC's, setting the correct `nonceCaller`/`nonceTPM`, etc. I'm planning on spending quite some time with this library, so expect more upcoming changes - _if appreciated_.

Essentially replaces https://github.com/tpm-rs/tpm-rs/pull/152

EDIT: See https://github.com/tpm-rs/tpm-rs/pull/199#issuecomment-3294498147 for demo,