### PR TITLE
Allow for the creation of multiple TcpSimulators.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ proc-macro2 = "1"
 quote = "1"
 safe-discriminant = "0.2.0"
 syn = { version = "2", features = ["full"] }
+tempfile = "3.25.0"
 trybuild = { version = "1.0.89", features = ["diff"] }
 zerocopy = { version = "0.8.33", features = ["derive"] }
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -16,9 +16,10 @@ zerocopy = { workspace = true, optional = true }
 
 [dev-dependencies]
 tpm2-rs-unionify = { workspace = true }
+tempfile = { workspace = true }
 
 [[test]]
 name = "simulator"
 path = "tests/simulator.rs"
-test = false # Do not test by default
+test = false                           # Do not test by default
 required-features = ["connection-tcp"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,5 +21,6 @@ tempfile = { workspace = true }
 [[test]]
 name = "simulator"
 path = "tests/simulator.rs"
-test = false                           # Do not test by default
+# Do not test by default
+test = false
 required-features = ["connection-tcp"]

--- a/client/compose.yaml
+++ b/client/compose.yaml
@@ -3,5 +3,4 @@ services:
     build: .
     volumes:
       - ../:/tpm-rs
-    # Simulator tests must be single-threaded because they use a single TCP port.
-    command: bash -c 'cargo test -p tpm2-rs-client --test simulator -- --nocapture'
+    command: bash -c 'cargo test -p tpm2-rs-client --test simulator'

--- a/client/compose.yaml
+++ b/client/compose.yaml
@@ -2,6 +2,6 @@ services:
   simulator_tests:
     build: .
     volumes:
-       - ../:/tpm-rs
+      - ../:/tpm-rs
     # Simulator tests must be single-threaded because they use a single TCP port.
-    command: bash -c 'cargo test -p tpm2-rs-client --test simulator -- --nocapture --test-threads=1'
+    command: bash -c 'cargo test -p tpm2-rs-client --test simulator -- --nocapture'

--- a/client/src/connection/tcp.rs
+++ b/client/src/connection/tcp.rs
@@ -13,7 +13,6 @@ use std::io::{Error, ErrorKind, IoSlice, Read, Result, Write};
 use std::net::TcpStream;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
-use std::string::String;
 use std::vec::Vec;
 
 use zerocopy::network_endian::U32;
@@ -691,11 +690,6 @@ impl TcpSimulator {
                 }
             }
         }
-    }
-
-    /// Collects stdout and stderr from the simulator.
-    pub fn collect_output(&mut self) -> Result<String> {
-        Err(Error::other("Unimplemented"))
     }
 
     /// Stops the TPM simulator process nicely.

--- a/client/src/connection/tcp.rs
+++ b/client/src/connection/tcp.rs
@@ -7,16 +7,15 @@
 #![cfg(feature = "connection-tcp")]
 extern crate std;
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsStr;
 use std::format;
-use std::io::{BufReader, Error, ErrorKind, IoSlice, Read, Result, Write};
+use std::io::{Error, ErrorKind, IoSlice, Read, Result, Write};
 use std::net::TcpStream;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::string::String;
-use std::thread;
+use std::vec::Vec;
 
-use thread::JoinHandle;
 use zerocopy::network_endian::U32;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
@@ -626,8 +625,6 @@ struct SetFirmwareSvnRequest {
 #[derive(Debug)]
 pub struct TcpSimulator {
     child: Child,
-    stdout_thread: Option<JoinHandle<String>>,
-    stderr_thread: Option<JoinHandle<String>>,
     conn: TcpConnection,
 }
 
@@ -645,53 +642,21 @@ impl TcpSimulator {
             command.args(args);
         }
 
-        let mut child = command
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+        let child = command
+            // TODO: Capture stdout/stderr to display when requested.
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .spawn()
             .map_err(|e| {
-                let argstr = if !args.is_empty() {
-                    // Ideally this would just be `args.join(" ")`, but the join
-                    // impl for OsStr is a permanent unstable feature, see
-                    // https://github.com/rust-lang/rust/issues/27747.
-                    let mut argstr = OsString::new();
-                    for arg in args {
-                        argstr.push(" ");
-                        argstr.push(arg);
-                    }
-                    argstr
-                } else {
-                    OsString::new()
-                };
-                Error::other(format!(
-                    "failed to start TCP simulator \"{}{}\": {e}",
-                    bin.as_ref().to_string_lossy(),
-                    argstr.to_string_lossy()
-                ))
+                Error::new(
+                    e.kind(),
+                    format!(
+                        "failed to start TCP simulator \"{:?} {:?}\": {e}",
+                        command.get_program(),
+                        command.get_args().collect::<Vec<_>>(),
+                    ),
+                )
             })?;
-
-        // Capture stdout and stderr for logging. Note that this implementation
-        // only allows the main thread to receive stdout/stderr after the
-        // simulator process terminates.
-        let child_stdout = child.stdout.take().ok_or(Error::other(
-            "failed to acquire stdout of simulator process",
-        ))?;
-        let stdout_thread = Some(thread::spawn(move || {
-            let mut s = String::new();
-            let mut reader = BufReader::new(child_stdout);
-            let _ = reader.read_to_string(&mut s);
-            s
-        }));
-
-        let child_stderr = child.stderr.take().ok_or(Error::other(
-            "failed to acquire stderr of simulator process",
-        ))?;
-        let stderr_thread = Some(thread::spawn(move || {
-            let mut s = String::new();
-            let mut reader = BufReader::new(child_stderr);
-            let _ = reader.read_to_string(&mut s);
-            s
-        }));
 
         // The TCG TPM simulator writes the ports it uses to two files:
         //   - TPM port: "command.port"
@@ -702,12 +667,7 @@ impl TcpSimulator {
 
         let conn = TcpConnection::connect_with_retries(ip, Some(tpm_port), Some(plat_port))?;
 
-        Ok(TcpSimulator {
-            child,
-            stdout_thread,
-            stderr_thread,
-            conn,
-        })
+        Ok(TcpSimulator { child, conn })
     }
 
     /// Reads a port from a file with retires.
@@ -733,25 +693,9 @@ impl TcpSimulator {
         }
     }
 
-    /// Collects stdout and stderr from the simulator. It is assumed that the
-    /// simulator has already been stopped.
+    /// Collects stdout and stderr from the simulator.
     pub fn collect_output(&mut self) -> Result<String> {
-        let stdout = self
-            .stdout_thread
-            .take()
-            .ok_or_else(|| Error::other("stdout_thread already taken"))?
-            .join()
-            .map_err(|e| Error::other(format!("failed to join stdout thread: {e:?}")))?;
-        let stderr = self
-            .stderr_thread
-            .take()
-            .ok_or_else(|| Error::other("stderr_thread already taken"))?
-            .join()
-            .map_err(|e| Error::other(format!("failed to join stderr thread: {e:?}")))?;
-
-        Ok(format!(
-            "--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
-        ))
+        Err(Error::other("Unimplemented"))
     }
 
     /// Stops the TPM simulator process nicely.

--- a/client/tests/simulator.rs
+++ b/client/tests/simulator.rs
@@ -9,6 +9,7 @@
 /// These tests must be run with `--test-threads=1`, because they use a single TCP port.
 use std::io::Result;
 
+use tempfile::tempdir;
 use tpm2_rs_base::commands::StartupCmd;
 use tpm2_rs_base::constants::TpmSu;
 use tpm2_rs_client::connection::TcpSimulator;
@@ -55,7 +56,7 @@ fn get_simulator_path() -> String {
 const ENV_VAR_SIMULATOR_ARGS: &str = "SIMULATOR_ARGS";
 
 /// Default arguments to pass to the TPM simulator.
-const DEFAULT_SIMULATOR_ARGS: &str = "";
+const DEFAULT_SIMULATOR_ARGS: &str = "--pick_ports";
 
 /// Get the arguments to pass to the TPM simulator. Set the environment
 /// variable at the command line to specify different arguments, e.g.
@@ -73,9 +74,11 @@ fn get_simulator_args() -> Vec<String> {
 
 /// Convenience function to spawn a TPM simulator and establish a TCP connection.
 pub fn spawn_simulator_and_connect() -> Result<TcpSimulator> {
+    let tempdir = tempdir()?;
     let mut simulator = TcpSimulator::new(
         get_simulator_path(),
         get_simulator_args().as_slice(),
+        tempdir.keep(), // cwd
         &get_simulator_ip(),
     )?;
     simulator.connection_mut().reinit()?;

--- a/client/tests/simulator.rs
+++ b/client/tests/simulator.rs
@@ -8,6 +8,7 @@
 ///
 /// These tests must be run with `--test-threads=1`, because they use a single TCP port.
 use std::io::Result;
+use std::net::Ipv4Addr;
 
 use tempfile::tempdir;
 use tpm2_rs_base::commands::StartupCmd;
@@ -17,23 +18,6 @@ use tpm2_rs_client::run_command;
 
 // Include the command-specific tests
 mod commands;
-
-/// Environment variable used to connect to the TPM simulator over TCP.
-const ENV_VAR_SIMULATOR_IP: &str = "SIMULATOR_IP";
-
-/// Default IP address of the TPM simulator program. This value assumes the
-/// simulator is running on the same location as the test.
-const DEFAULT_SIMULATOR_IP: &str = "127.0.0.1";
-
-/// Get the IP address to connect to the TPM simulator. Set the environment
-/// variable at the command line to specify a different IP address, e.g.
-///
-/// ```shell
-/// SIMULATOR_IP="192.168.1.1" cargo test
-/// ```
-fn get_simulator_ip() -> String {
-    std::env::var(ENV_VAR_SIMULATOR_IP).unwrap_or(DEFAULT_SIMULATOR_IP.to_string())
-}
 
 /// Environment variable used to override the TPM simulator program.
 const ENV_VAR_SIMULATOR_PROGRAM: &str = "SIMULATOR_BIN";
@@ -52,34 +36,14 @@ fn get_simulator_path() -> String {
     std::env::var(ENV_VAR_SIMULATOR_PROGRAM).unwrap_or(DEFAULT_SIMULATOR_PROGRAM.to_string())
 }
 
-/// Environment variable used to override the arguments to the TPM simulator.
-const ENV_VAR_SIMULATOR_ARGS: &str = "SIMULATOR_ARGS";
-
-/// Default arguments to pass to the TPM simulator.
-const DEFAULT_SIMULATOR_ARGS: &str = "--pick_ports";
-
-/// Get the arguments to pass to the TPM simulator. Set the environment
-/// variable at the command line to specify different arguments, e.g.
-///
-/// ```shell
-/// SIMULATOR_ARGS="--custom-arg" cargo test
-/// ```
-fn get_simulator_args() -> Vec<String> {
-    std::env::var(ENV_VAR_SIMULATOR_ARGS)
-        .unwrap_or(DEFAULT_SIMULATOR_ARGS.to_string())
-        .split_whitespace()
-        .map(|s| s.to_string())
-        .collect()
-}
-
 /// Convenience function to spawn a TPM simulator and establish a TCP connection.
 pub fn spawn_simulator_and_connect() -> Result<TcpSimulator> {
     let tempdir = tempdir()?;
     let mut simulator = TcpSimulator::new(
         get_simulator_path(),
-        get_simulator_args().as_slice(),
+        &["--pick_ports"],
         tempdir.keep(), // cwd
-        &get_simulator_ip(),
+        &Ipv4Addr::LOCALHOST.to_string(),
     )?;
     simulator.connection_mut().reinit()?;
 


### PR DESCRIPTION
- The TCG reference simulator writes the ports it uses to `command.port` and `platform.port` in the directory of the spawned simulator process. Rather than assume default ports, the TcpConnection associated with the simulator now parses those files for the ports to use.
- Combine that with the use of a temporary directory for each integration test and now the integration tests all run in parallel (we can drop the `--test-threads=1` parameter from the tests).

Before: `test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.03s`
After: `test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.01s`

- Since the simulator now runs in parallel, also provide utilities for capturing stdout/stderr. This prevents the code from interleaving test output. As part of this change, we no longer need the `nocapture` flag, since this feature now allows the capture and handling of the simulator. It's particularly useful in tests like this:

```rust
#[test]
simulator_test() -> Result<()> {
    let mut simulator = TcpSimulator::new( ... )?;

    // run command that returns result ...
    let result = ...

    if result.is_err() {
        if simulator.stop_nicely().is_ok()
            && let Ok(output) = simulator.collect_output()
        {
            println!("{output}");
        }
    }
}
```

Future improvements:

- Don't persist the temporary directory via the `keep()` function. This isn't a big deal since we're running in an ephemeral container anyways, but it's possible to refactor the test code to properly maintain the scope of the temporary directory.