### PR TITLE
tpm2: Modularize trait implementations and complete basic marshalling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.87"
 homepage = "https://github.com/tpm-rs"
 repository = "https://github.com/tpm-rs/tpm-rs"
 license = "Apache-2.0"

--- a/crates/tpm2/src/commands/mod.rs
+++ b/crates/tpm2/src/commands/mod.rs
@@ -6,12 +6,14 @@
 //! Command structs appear without the leading `TPM2_`. For example, the
 //! `TPM2_GetRandom` command in the spec corresponds to [`GetRandom`].
 //!
-//! Using the [`Command::Response`] associated type is preffered to using the
+//! Using the [`Command::Response`] associated type is preferred to using the
 //! standalone type in the [`responses`] sub-module. For example, when referring
 //! to the TPM2_GetRandom Response, prefer [`GetRandom::Response`]
 //! for `TPM2_GetRandom` should use ``
 //! Generally, the type of a command's
 //! response
+
+use crate::{Marshal, Unmarshal, errors::UnmarshalError};
 
 /// TPM2 Responses
 ///
@@ -29,12 +31,28 @@ pub trait Command {
 ///
 /// Returns the next `bytesRequested` octets from the random number generator (RNG).
 #[doc(alias("TPM2_GetRandom", "GetRandom_In"))]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct GetRandom {
     pub bytes_requested: u16,
 }
 
-// TODO: Implement these with a proc-macro or macro_rules!
+// *** Command/Marshal/Unmarsahl implementations ***
+
 impl Command for GetRandom {
     type Response<'a> = responses::GetRandom<'a>;
+}
+impl Marshal for GetRandom {
+    const MAX_SIZE: usize = u16::MAX_SIZE;
+    type MaxBuffer = [u8; Self::MAX_SIZE];
+
+    fn marshal(&self, dst: &mut [u8; Self::MAX_SIZE]) -> usize {
+        self.bytes_requested.marshal(dst)
+    }
+}
+impl<'a> Unmarshal<'a> for GetRandom {
+    fn unmarshal(src: &mut &'a [u8]) -> Result<Self, UnmarshalError> {
+        Ok(Self {
+            bytes_requested: u16::unmarshal(src)?,
+        })
+    }
 }

--- a/crates/tpm2/src/commands/responses.rs
+++ b/crates/tpm2/src/commands/responses.rs
@@ -1,8 +1,0 @@
-use crate::Tpm2bDigest;
-
-/// Random bytes retuned by the RNG
-#[doc(alias("GetRandom_Out"))]
-#[derive(Clone, Copy, Debug)]
-pub struct GetRandom<'a> {
-    pub random_bytes: Tpm2bDigest<'a>,
-}

--- a/crates/tpm2/src/commands/responses/mod.rs
+++ b/crates/tpm2/src/commands/responses/mod.rs
@@ -1,0 +1,27 @@
+use crate::{Marshal, Tpm2bDigest, Unmarshal, errors::UnmarshalError};
+
+/// Random bytes returned by the RNG
+#[doc(alias("GetRandom_Out"))]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct GetRandom<'a> {
+    /// The generated random bytes.
+    pub random_bytes: Tpm2bDigest<'a>,
+}
+
+// *** Marshal/Unmarshal implementations ***
+
+impl<'a> Marshal for GetRandom<'a> {
+    const MAX_SIZE: usize = Tpm2bDigest::MAX_SIZE;
+    type MaxBuffer = [u8; GetRandom::MAX_SIZE];
+
+    fn marshal(&self, dst: &mut [u8; Tpm2bDigest::MAX_SIZE]) -> usize {
+        self.random_bytes.marshal(dst)
+    }
+}
+impl<'a> Unmarshal<'a> for GetRandom<'a> {
+    fn unmarshal(src: &mut &'a [u8]) -> Result<Self, UnmarshalError> {
+        Ok(Self {
+            random_bytes: Tpm2bDigest::unmarshal(src)?,
+        })
+    }
+}

--- a/crates/tpm2/src/constants.rs
+++ b/crates/tpm2/src/constants.rs
@@ -1,8 +1,8 @@
-//! Definitions of constants and identifier types for TPM 2.0
+//! Constants and C-like enums
 
-use core::convert::Infallible;
+use core::fmt::Debug;
 
-use crate::{MarshalArray, UnmarshalArray};
+use crate::{BE, Marshal, Unmarshal, errors::UnmarshalError};
 
 /// Algorithms defined by either the `TPM_ALG_ID` listing in Part 2 of the
 /// [TPM2 Specification] or the `TCG_ALG_ID` list in the
@@ -11,64 +11,76 @@ use crate::{MarshalArray, UnmarshalArray};
 /// [TPM2 Specification]: https://trustedcomputinggroup.org/work-groups/trusted-platform-module/
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(transparent)]
-pub struct Alg(pub u16);
+pub struct Alg(pub(crate) BE<u16>);
 
 // We do this for naming consistency with the other algorithm enums.
 // TODO: Should this just be an enum?
 #[allow(non_upper_case_globals)]
 impl Alg {
-    pub const Rsa: Self = Self(0x0001);
-    pub const Tdes: Self = Self(0x0003);
-    pub const Sha1: Self = Self(0x0004);
-    pub const Hmac: Self = Self(0x0005);
-    pub const Aes: Self = Self(0x0006);
-    pub const Mgf1: Self = Self(0x0007);
-    pub const KeyedHash: Self = Self(0x0008);
-    pub const Null: Self = Self(0x0010);
-    pub const Xor: Self = Self(0x000A);
-    pub const Sha256: Self = Self(0x000B);
-    pub const Sha384: Self = Self(0x000C);
-    pub const Sha512: Self = Self(0x000D);
-    pub const Sm3_256: Self = Self(0x0012);
-    pub const Sm4: Self = Self(0x0013);
-    pub const RsaSsa: Self = Self(0x0014);
-    pub const RsaEs: Self = Self(0x0015);
-    pub const RsaPss: Self = Self(0x0016);
-    pub const Oaep: Self = Self(0x0017);
-    pub const Ecdsa: Self = Self(0x0018);
-    pub const Ecdh: Self = Self(0x0019);
-    pub const Ecdaa: Self = Self(0x001A);
-    pub const Sm2: Self = Self(0x001B);
-    pub const EcSchnorr: Self = Self(0x001C);
-    pub const Ecmqv: Self = Self(0x001D);
-    pub const Kdf1Sp800_56A: Self = Self(0x0020);
-    pub const Kdf2: Self = Self(0x0021);
-    pub const Kdf1Sp800_108: Self = Self(0x0022);
-    pub const Ecc: Self = Self(0x0023);
-    pub const SymCipher: Self = Self(0x0025);
-    pub const Camellia: Self = Self(0x0026);
-    pub const Sha3_256: Self = Self(0x0027);
-    pub const Sha3_384: Self = Self(0x0028);
-    pub const Sha3_512: Self = Self(0x0029);
-    pub const Ctr: Self = Self(0x0040);
-    pub const Ofb: Self = Self(0x0041);
-    pub const Cbc: Self = Self(0x0042);
-    pub const Cfb: Self = Self(0x0043);
-    pub const Ecb: Self = Self(0x0044);
+    /// Creates a new [`Alg`] from raw 16-bit algorithm ID numerical value.
+    #[inline(always)]
+    pub const fn new(id: u16) -> Self {
+        Self(BE::<u16>::new(id))
+    }
+
+    pub const Rsa: Self = Self::new(0x0001);
+    pub const Tdes: Self = Self::new(0x0003);
+    pub const Sha1: Self = Self::new(0x0004);
+    pub const Hmac: Self = Self::new(0x0005);
+    pub const Aes: Self = Self::new(0x0006);
+    pub const Mgf1: Self = Self::new(0x0007);
+    pub const KeyedHash: Self = Self::new(0x0008);
+    pub const Null: Self = Self::new(0x0010);
+    pub const Xor: Self = Self::new(0x000A);
+    pub const Sha256: Self = Self::new(0x000B);
+    pub const Sha384: Self = Self::new(0x000C);
+    pub const Sha512: Self = Self::new(0x000D);
+    pub const Sm3_256: Self = Self::new(0x0012);
+    pub const Sm4: Self = Self::new(0x0013);
+    pub const RsaSsa: Self = Self::new(0x0014);
+    pub const RsaEs: Self = Self::new(0x0015);
+    pub const RsaPss: Self = Self::new(0x0016);
+    pub const Oaep: Self = Self::new(0x0017);
+    pub const Ecdsa: Self = Self::new(0x0018);
+    pub const Ecdh: Self = Self::new(0x0019);
+    pub const Ecdaa: Self = Self::new(0x001A);
+    pub const Sm2: Self = Self::new(0x001B);
+    pub const EcSchnorr: Self = Self::new(0x001C);
+    pub const Ecmqv: Self = Self::new(0x001D);
+    pub const Kdf1Sp800_56A: Self = Self::new(0x0020);
+    pub const Kdf2: Self = Self::new(0x0021);
+    pub const Kdf1Sp800_108: Self = Self::new(0x0022);
+    pub const Ecc: Self = Self::new(0x0023);
+    pub const SymCipher: Self = Self::new(0x0025);
+    pub const Camellia: Self = Self::new(0x0026);
+    pub const Sha3_256: Self = Self::new(0x0027);
+    pub const Sha3_384: Self = Self::new(0x0028);
+    pub const Sha3_512: Self = Self::new(0x0029);
+    pub const Ctr: Self = Self::new(0x0040);
+    pub const Ofb: Self = Self::new(0x0041);
+    pub const Cbc: Self = Self::new(0x0042);
+    pub const Cfb: Self = Self::new(0x0043);
+    pub const Ecb: Self = Self::new(0x0044);
 }
 
-impl MarshalArray for Alg {
-    const SIZE: usize = 2;
-    type Array = [u8; 2];
-    #[inline(always)]
-    fn marshal_array(&self, arr: &mut [u8; Self::SIZE]) {
-        self.0.marshal_array(arr)
+impl Default for Alg {
+    fn default() -> Self {
+        Self::Null
     }
 }
-impl UnmarshalArray for Alg {
-    type Error = Infallible;
+
+// *** Marshal/Unmarshal implementations ***
+impl Marshal for Alg {
+    const MAX_SIZE: usize = <BE<u16> as Marshal>::MAX_SIZE;
+    type MaxBuffer = [u8; Self::MAX_SIZE];
+
+    fn marshal(&self, dst: &mut Self::MaxBuffer) -> usize {
+        self.0.marshal(dst)
+    }
+}
+impl<'a> Unmarshal<'a> for Alg {
     #[inline(always)]
-    fn unmarshal_array(arr: &[u8; Self::SIZE]) -> Result<Self, Infallible> {
-        Ok(Self(u16::unmarshal_array(arr)?))
+    fn unmarshal(src: &mut &'a [u8]) -> Result<Self, UnmarshalError> {
+        Unmarshal::unmarshal(src).map(Self)
     }
 }

--- a/crates/tpm2/src/errors/mod.rs
+++ b/crates/tpm2/src/errors/mod.rs
@@ -15,10 +15,6 @@ mod std;
 mod tpm_rc;
 mod tss_rc;
 
-/// Any error which can happen when marshalling
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct MarshalError;
-
 /// Any error which can happen when unmarshalling
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct UnmarshalError;

--- a/crates/tpm2/src/lib.rs
+++ b/crates/tpm2/src/lib.rs
@@ -51,32 +51,26 @@
 //!
 //! [build-dependencies]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#build-dependencies
 //! [dev-dependencies]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#development-dependencies
+//!
+//! ## Submodule Organization
+//!
+//! Internally, we use submodules for code organization, but mostly present a
+//! flat API to external users, with the exception of the [`commands`] and
+//! [`errors`] submodules.
 #![no_std]
 
-// We use submodules for code organization, but mostly present a flat API to
-// external users, with the exception of the commands and errors modules.
 pub mod commands;
-mod constants;
-pub mod errors;
-mod marshal;
-mod tpm2b;
-mod tpmi;
-mod tpmt;
-
 pub use commands::Command;
-pub use constants::*;
+pub mod errors;
+
+// Reexport for a flat API.
+mod marshal;
 pub use marshal::*;
+mod constants;
+pub use constants::*;
+mod tpm2b;
 pub use tpm2b::*;
+mod tpmi;
 pub use tpmi::*;
+mod tpmt;
 pub use tpmt::*;
-
-#[cfg(test)]
-mod test {
-    use crate::TpmtHa;
-
-    #[test]
-    fn size_of_tpmt_ha() {
-        assert_eq!(size_of::<TpmtHa>(), 2 * size_of::<usize>());
-        assert_eq!(size_of::<Option<TpmtHa>>(), 2 * size_of::<usize>());
-    }
-}

--- a/crates/tpm2/src/marshal.rs
+++ b/crates/tpm2/src/marshal.rs
@@ -1,145 +1,154 @@
-//! Submodule defining traits used for Marshalling and Unmarshalling
+//! Marshalling and Unmarshalling traits
+use core::fmt;
 
-use core::convert::Infallible;
+use crate::errors::UnmarshalError;
 
-use crate::{
-    TpmiAlgHash,
-    errors::{MarshalError, UnmarshalError},
-};
-
-/// Allows an implementation to restrict which values it can [`Marshal`] and
-/// [`Unmarshal`].
+/// A type that can be marshalled into a destination byte buffer.
 ///
-/// This trait enables different implementations to share the same core type
-/// definitions while selectively supporting only a subset of variants. This
-/// selection can be enforced either at compile time or at runtime.
+/// [`Self::MaxBuffer`] is always [`[u8; Self::MAX_SIZE]`](Self::MAX_SIZE),
+/// so types should implement this trait like:
+/// ```
+/// # use tpm2::Marshal;
+/// # const fn calculate_foo_max_size() -> usize { 42 }
+/// struct Foo;
 ///
-/// This approach is important for two main reasons:
+/// impl Marshal for Foo {
+///     const MAX_SIZE: usize = calculate_foo_max_size();
+///     type MaxBuffer = [u8; Self::MAX_SIZE];
 ///
-/// 1.  **ABI Stability**: It avoids the many compile-time `#define`s found in C
-///     implementations. Those defines often alter structure layouts, leading to
-///     API and ABI incompatibilities between libraries compiled with different
-///     options.
-///
-/// 2.  **Code Size**: Restricting which algorithms and types the marshaling code
-///     must support can significantly reduce the final binary size, which is
-///     critical for constrained environments.
-pub trait Limits: Copy {
-    fn supports_hash(self, h: TpmiAlgHash) -> bool;
-
-    fn max_digest_size(self) -> usize {
-        for &h in TpmiAlgHash::BY_SIZE_DESC {
-            if self.supports_hash(h) {
-                return h.digest_size();
-            }
-        }
-        0
-    }
-}
-
-/// A type that can be marshalled into a destincation byte buffer
+///     fn marshal(&self, dst: &mut [u8; Self::MAX_SIZE]) -> usize {
+///         todo!()
+///     }
+/// }
+/// ```
 pub trait Marshal {
-    fn marshal<'dst>(
-        &self,
-        limits: impl Limits,
-        buf: &'dst mut [u8],
-    ) -> Result<&'dst mut [u8], MarshalError>;
-    fn marshaled_size(&self) -> usize;
-    fn marshaled_size_max(limits: impl Limits) -> usize;
+    /// The maximum possible size (in bytes) of this structure when encoded.
+    const MAX_SIZE: usize;
+    /// [`[u8; Self::MAX_SIZE]`](Self::MAX_SIZE)
+    ///
+    /// However, this has to be part of the trait definition until
+    /// [`#![feature(min_generic_const_args)]`](https://doc.rust-lang.org/nightly/unstable-book/language-features/min-generic-const-args.html#min_generic_const_args)
+    /// is finalized.
+    type MaxBuffer;
+
+    /// Marshals the structure into the provided array, which will always be
+    /// `&mut`[`[u8; Self::MAX_SIZE]`](Self::MAX_SIZE).
+    fn marshal(&self, dst: &mut Self::MaxBuffer) -> usize;
 }
 
-/// A type that can be unmarshalled from a source byte buffer
-pub trait Unmarshal<'src> {
-    fn unmarshal(
-        &mut self,
-        limits: impl Limits,
-        buf: &'src [u8],
-    ) -> Result<&'src [u8], UnmarshalError>;
+/// A type that can be unmarshalled from a source byte buffer.
+pub trait Unmarshal<'a>: Sized {
+    /// Unmarshals the structure from the provided byte buffer, modifying the
+    /// structure in-place.
+    ///
+    /// On success, returns the remaining, unused bytes from `src`.
+    fn unmarshal_ref(&mut self, mut src: &'a [u8]) -> Result<&'a [u8], UnmarshalError> {
+        *self = Self::unmarshal(&mut src)?;
+        Ok(src)
+    }
+
+    /// Returns a value unmarshaled from `*src`.
+    ///
+    /// On success, `*src` will be the remaining, unused bytes. On failure,
+    /// `*src` will be unmodified.
+    fn unmarshal(src: &mut &'a [u8]) -> Result<Self, UnmarshalError>;
 }
 
-/// A type that has a consistent size when marshalled
-pub trait MarshalArray: Marshal {
-    const SIZE: usize;
-    /// This type will always be `[u8; Self::SIZE]`. However, until the
-    /// [`min_generic_const_args` feature](https://doc.rust-lang.org/nightly/unstable-book/language-features/min-generic-const-args.html#min_generic_const_args)
-    /// is stabilized, we need this type to write the signature of
-    /// [`marshal_array`][MarshalArray::marshal_array].
-    type Array;
-    /// Infallible as we statically know the buffer is long enough
-    fn marshal_array(&self, arr: &mut Self::Array);
-}
-// Blanket impl so a type only needs to implement `marshal_array()`.
-impl<T: MarshalArray<Array = [u8; N]>, const N: usize> Marshal for T {
+impl<const N: usize> Marshal for [u8; N] {
+    const MAX_SIZE: usize = N;
+    type MaxBuffer = [u8; N];
     #[inline(always)]
-    fn marshal<'dst>(
-        &self,
-        _: impl Limits,
-        buf: &'dst mut [u8],
-    ) -> Result<&'dst mut [u8], MarshalError> {
-        let (arr, buf) = buf.split_first_chunk_mut().ok_or(MarshalError)?;
-        self.marshal_array(arr);
-        Ok(buf)
-    }
-    #[inline(always)]
-    fn marshaled_size(&self) -> usize {
-        Self::SIZE
-    }
-    #[inline(always)]
-    fn marshaled_size_max(_: impl Limits) -> usize {
-        Self::SIZE
+    fn marshal(&self, dst: &mut [u8; N]) -> usize {
+        *dst = *self;
+        N
     }
 }
 
-/// Similar to [`MarshalArray`] but for unmarshalling
-///
-/// This trait doesn't have a `'src` lifetime parameter like [`Unmarshal`], as
-/// types with fixed [`SIZE`][`MarshalArray::SIZE`] don't need to retain
-/// references to the source buffer.
-pub trait UnmarshalArray: Sized + MarshalArray + for<'src> Unmarshal<'src>
-where
-    UnmarshalError: From<Self::Error>,
-{
-    type Error;
-    /// This can still fail if the source buffer has a bad value, but we know
-    /// we have a buffer of the correct length.
-    fn unmarshal_array(arr: &Self::Array) -> Result<Self, Self::Error>;
+/// Unmarshals a reference to a fixed-size byte array `&'a [u8; N]` from `src`.
+#[inline(always)]
+pub(crate) fn unmarshal_array_ref<'a, const N: usize>(
+    src: &mut &'a [u8],
+) -> Result<&'a [u8; N], UnmarshalError> {
+    let (arr, rest) = src.split_first_chunk().ok_or(UnmarshalError)?;
+    *src = rest;
+    Ok(arr)
 }
-// Blanket impl so a type only needs to implement `unmarshal_array()`.
-impl<'src, T: UnmarshalArray<Array = [u8; N]>, const N: usize> Unmarshal<'src> for T
-where
-    UnmarshalError: From<T::Error>,
-{
+
+impl<'a, const N: usize> Unmarshal<'a> for [u8; N] {
     #[inline(always)]
-    fn unmarshal(&mut self, _: impl Limits, buf: &'src [u8]) -> Result<&'src [u8], UnmarshalError> {
-        let (arr, buf) = buf.split_first_chunk().ok_or(UnmarshalError)?;
-        *self = Self::unmarshal_array(arr)?;
-        Ok(buf)
+    fn unmarshal(src: &mut &'a [u8]) -> Result<Self, UnmarshalError> {
+        unmarshal_array_ref(src).copied()
+    }
+    #[inline(always)]
+    fn unmarshal_ref(&mut self, mut src: &'a [u8]) -> Result<&'a [u8], UnmarshalError> {
+        *self = *unmarshal_array_ref(&mut src)?;
+        Ok(src)
+    }
+}
+impl<'a, const N: usize> Unmarshal<'a> for &'a [u8; N] {
+    #[inline(always)]
+    fn unmarshal(src: &mut &'a [u8]) -> Result<Self, UnmarshalError> {
+        unmarshal_array_ref(src)
+    }
+    #[inline(always)]
+    fn unmarshal_ref(&mut self, mut src: &'a [u8]) -> Result<&'a [u8], UnmarshalError> {
+        *self = unmarshal_array_ref(&mut src)?;
+        Ok(src)
     }
 }
 
-/// Implement [`MarshalArray`] and [`UnmarshalArray`] for integer types
+/// A wrapper type for numeric values stored in big-endian byte order.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[repr(transparent)]
+pub(crate) struct BE<T>(pub(crate) T);
+
 macro_rules! impl_ints { ($($T: ty),+) => { $(
-    impl MarshalArray for $T {
-        const SIZE: usize = size_of::<Self>();
-        type Array = [u8; size_of::<Self>()];
-        fn marshal_array(&self, arr: &mut [u8; Self::SIZE]) {
-            *arr = self.to_be_bytes();
+    impl Marshal for $T {
+        const MAX_SIZE: usize = size_of::<Self>();
+        type MaxBuffer = [u8; Self::MAX_SIZE];
+
+        #[inline(always)]
+        fn marshal(&self, dst: &mut [u8; Self::MAX_SIZE]) -> usize {
+            self.to_be_bytes().marshal(dst)
         }
     }
-    impl UnmarshalArray for $T {
-        type Error = Infallible;
-        fn unmarshal_array(arr: &[u8; Self::SIZE]) -> Result<Self, Infallible> {
-            Ok(Self::from_be_bytes(*arr))
+    impl<'a> Unmarshal<'a> for $T {
+        #[inline(always)]
+        fn unmarshal(src: &mut &[u8]) -> Result<Self, UnmarshalError> {
+            Unmarshal::unmarshal(src).map(Self::from_be_bytes)
+        }
+    }
+
+    impl BE<$T> {
+        #[inline(always)]
+        #[allow(dead_code)]
+        pub const fn new(t: $T) -> Self {
+            Self(t.to_be())
+        }
+        #[inline(always)]
+        pub const fn get(self) -> $T {
+            <$T>::from_be(self.0)
+        }
+    }
+    impl Marshal for BE<$T> {
+        const MAX_SIZE: usize = size_of::<Self>();
+        type MaxBuffer = [u8; Self::MAX_SIZE];
+
+        #[inline(always)]
+        fn marshal(&self, dst: &mut [u8; Self::MAX_SIZE]) -> usize {
+            self.0.to_ne_bytes().marshal(dst)
+        }
+    }
+    impl<'a> Unmarshal<'a> for BE<$T> {
+        #[inline(always)]
+        fn unmarshal(src: &mut &[u8]) -> Result<Self, UnmarshalError> {
+            Ok(Self(<$T>::from_ne_bytes(Unmarshal::unmarshal(src)?)))
+        }
+    }
+    impl fmt::Debug for BE<$T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            self.get().fmt(f)
         }
     }
 )+ } }
 impl_ints!(u8, u16, u32, u64, i8, i16, i32, i64);
-
-impl<const N: usize> MarshalArray for [u8; N] {
-    const SIZE: usize = N;
-    type Array = [u8; N];
-    #[inline(always)]
-    fn marshal_array(&self, arr: &mut [u8; N]) {
-        *arr = *self;
-    }
-}

--- a/crates/tpm2/src/tpm2b.rs
+++ b/crates/tpm2/src/tpm2b.rs
@@ -1,1 +1,57 @@
-pub type Tpm2bDigest<'a> = &'a [u8];
+use crate::{Marshal, TpmiAlgHash, Unmarshal, errors::UnmarshalError};
+
+/// A TPM 2.0 sized buffer wrapper holding up to `N` bytes.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub struct Tpm2b<'a, const N: usize>(&'a [u8]);
+
+impl<'a, const N: usize> Tpm2b<'a, N> {
+    pub const fn new(b: &'a [u8]) -> Option<Self> {
+        if b.len() <= N { Some(Self(b)) } else { None }
+    }
+    pub const fn bytes(self) -> &'a [u8] {
+        match self.0.split_at_checked(N) {
+            Some((s, _)) => {
+                debug_assert!(false, "Tpm2b inner data too long");
+                s
+            }
+            None => self.0,
+        }
+    }
+    #[inline(always)]
+    pub(crate) const fn marshal_helper<const M: usize>(self, dst: &mut [u8; M]) -> usize {
+        assert!(2 + N == M);
+        let (s_dst, rest) = dst.split_first_chunk_mut::<2>().unwrap();
+
+        let b = self.bytes();
+        *s_dst = (b.len() as u16).to_be_bytes();
+        let (b_dst, _) = rest.split_at_mut_checked(b.len()).unwrap();
+        b_dst.copy_from_slice(b);
+        2 + b.len()
+    }
+}
+
+impl<'a, const N: usize> Unmarshal<'a> for Tpm2b<'a, N> {
+    fn unmarshal(src: &mut &'a [u8]) -> Result<Self, UnmarshalError> {
+        let size: usize = u16::unmarshal(src)?.into();
+        let (s, rest) = src.split_at_checked(size).ok_or(UnmarshalError)?;
+        *src = rest;
+        Self::new(s).ok_or(UnmarshalError)
+    }
+}
+
+/// `TPM2B_DIGEST`
+#[doc(alias("TPM2B_DIGEST"))]
+pub type Tpm2bDigest<'a> = Tpm2b<'a, { TpmiAlgHash::MAX_DIGEST_SIZE }>;
+
+/// Implement Marshal for the different [`Tpm2b`]` sizes.
+macro_rules! impl_tpm2b_marshal { ($($N:expr),+) => { $(
+    impl Marshal for Tpm2b<'_, { $N }> {
+        const MAX_SIZE: usize = 2 + $N;
+        type MaxBuffer = [u8; 2 + $N];
+
+        fn marshal(&self, dst: &mut [u8; 2 + $N]) -> usize {
+            self.marshal_helper(dst)
+        }
+    }
+)+ }; }
+impl_tpm2b_marshal!(TpmiAlgHash::MAX_DIGEST_SIZE);

--- a/crates/tpm2/src/tpmi.rs
+++ b/crates/tpm2/src/tpmi.rs
@@ -1,28 +1,31 @@
-//! `TPMI_` interface types
 use crate::{
-    Alg,
+    Alg, BE, Marshal, Unmarshal,
     errors::{HashError, UnmarshalError},
-    marshal::{MarshalArray, UnmarshalArray},
 };
 
 /// `TPMI_ALG_HASH`
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 #[repr(u16)]
 #[non_exhaustive]
 pub enum TpmiAlgHash {
-    Sha1 = Alg::Sha1.0,
-    Sha256 = Alg::Sha256.0,
-    Sha384 = Alg::Sha384.0,
-    Sha512 = Alg::Sha512.0,
-    Sm3_256 = Alg::Sm3_256.0,
-    Sha3_256 = Alg::Sha3_256.0,
-    Sha3_384 = Alg::Sha3_384.0,
-    Sha3_512 = Alg::Sha3_512.0,
+    Sha1 = Alg::Sha1.0.0,
+    #[default]
+    Sha256 = Alg::Sha256.0.0,
+    Sha384 = Alg::Sha384.0.0,
+    Sha512 = Alg::Sha512.0.0,
+    Sm3_256 = Alg::Sm3_256.0.0,
+    Sha3_256 = Alg::Sha3_256.0.0,
+    Sha3_384 = Alg::Sha3_384.0.0,
+    Sha3_512 = Alg::Sha3_512.0.0,
 }
+use TpmiAlgHash::*;
 
 impl TpmiAlgHash {
+    /// The maximum digest size (in bytes) across all supported TPM2 hash algorithms.
+    pub const MAX_DIGEST_SIZE: usize = 64;
+
+    /// Returns the digest size (in bytes) of this hash algorithm.
     pub const fn digest_size(self) -> usize {
-        use TpmiAlgHash::*;
         match self {
             Sha1 => 20,
             Sha256 => 32,
@@ -34,21 +37,10 @@ impl TpmiAlgHash {
             Sha3_512 => 64,
         }
     }
-
-    /// Used for simple implementation of [`crate::Limits::max_digest_size`]
-    pub(crate) const BY_SIZE_DESC: &[Self] = const {
-        use TpmiAlgHash::*;
-        &[
-            Sha512, Sha3_512, // 64-byte digest
-            Sha384, Sha3_384, // 48-byte digest
-            Sha256, Sha3_256, Sm3_256, // 32-byte digest
-            Sha1,    // 20-byte digest
-        ]
-    };
 }
 impl From<TpmiAlgHash> for Alg {
     fn from(h: TpmiAlgHash) -> Alg {
-        Alg(h as u16)
+        Alg(BE(h as u16))
     }
 }
 impl TryFrom<Alg> for TpmiAlgHash {
@@ -68,19 +60,19 @@ impl TryFrom<Alg> for TpmiAlgHash {
         }
     }
 }
-impl MarshalArray for TpmiAlgHash {
-    const SIZE: usize = 2;
-    type Array = [u8; 2];
+
+// *** Marshal/Unamsrahl Implementations ***
+impl Marshal for TpmiAlgHash {
+    const MAX_SIZE: usize = Alg::MAX_SIZE;
+    type MaxBuffer = [u8; Self::MAX_SIZE];
+
     #[inline(always)]
-    fn marshal_array(&self, arr: &mut [u8; Self::SIZE]) {
-        Alg::from(*self).marshal_array(arr)
+    fn marshal(&self, dst: &mut [u8; Self::MAX_SIZE]) -> usize {
+        Alg::from(*self).marshal(dst)
     }
 }
-impl UnmarshalArray for TpmiAlgHash {
-    type Error = UnmarshalError;
-
-    fn unmarshal_array(arr: &[u8; Self::SIZE]) -> Result<Self, UnmarshalError> {
-        let Ok(alg) = Alg::unmarshal_array(arr);
-        alg.try_into().map_err(HashError::into)
+impl<'a> Unmarshal<'a> for TpmiAlgHash {
+    fn unmarshal(src: &mut &'a [u8]) -> Result<Self, UnmarshalError> {
+        Alg::unmarshal(src)?.try_into().map_err(|_| UnmarshalError)
     }
 }

--- a/crates/tpm2/src/tpmt.rs
+++ b/crates/tpm2/src/tpmt.rs
@@ -1,25 +1,21 @@
-//! `TPMT_` tagged union types
-
+use crate::{Alg, Marshal, TpmiAlgHash, Unmarshal, errors::UnmarshalError, unmarshal_array_ref};
 use TpmiAlgHash::*;
 
-use crate::{
-    Alg, Limits, Marshal, TpmiAlgHash, Unmarshal, UnmarshalArray,
-    errors::{MarshalError, UnmarshalError},
-};
 /// `TPMT_HA`
 ///
 /// There is no type for `TPMU_HA` in this crate, use this type instead.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(u16)]
 pub enum TpmtHa<'a> {
-    Sha1(&'a [u8; Sha1.digest_size()]) = Alg::Sha1.0,
-    Sha256(&'a [u8; Sha256.digest_size()]) = Alg::Sha256.0,
-    Sha384(&'a [u8; Sha384.digest_size()]) = Alg::Sha384.0,
-    Sha512(&'a [u8; Sha512.digest_size()]) = Alg::Sha512.0,
+    Sha1(&'a [u8; Sha1.digest_size()]),
+    Sha256(&'a [u8; Sha256.digest_size()]),
+    Sha384(&'a [u8; Sha384.digest_size()]),
+    Sha512(&'a [u8; Sha512.digest_size()]),
     // TODO: Add other Hash Algs
 }
 
 impl<'a> TpmtHa<'a> {
+    /// Returns the [`TpmiAlgHash`] corresponding to this digest.
     pub const fn hash_alg(self) -> TpmiAlgHash {
         match self {
             Self::Sha1(_) => Sha1,
@@ -28,6 +24,8 @@ impl<'a> TpmtHa<'a> {
             Self::Sha512(_) => Sha512,
         }
     }
+
+    /// Returns the underlying digest byte slice.
     pub fn digest(self) -> &'a [u8] {
         match self {
             Self::Sha1(d) => d,
@@ -38,60 +36,58 @@ impl<'a> TpmtHa<'a> {
     }
 }
 
-impl<'a> Marshal for TpmtHa<'a> {
-    fn marshal<'dst>(
-        &self,
-        limits: impl Limits,
-        buf: &'dst mut [u8],
-    ) -> Result<&'dst mut [u8], MarshalError> {
-        if !limits.supports_hash(self.hash_alg()) {
-            return Err(MarshalError);
-        }
-        let buf = self.hash_alg().marshal(limits, buf)?;
-        match self {
-            Self::Sha1(d) => d.marshal(limits, buf),
-            Self::Sha256(d) => d.marshal(limits, buf),
-            Self::Sha384(d) => d.marshal(limits, buf),
-            Self::Sha512(d) => d.marshal(limits, buf),
-        }
-    }
-    fn marshaled_size(&self) -> usize {
-        2 + self.hash_alg().digest_size()
-    }
-    fn marshaled_size_max(limits: impl Limits) -> usize {
-        2 + limits.max_digest_size()
+const EMPTY_SHA256: &[u8; Sha256.digest_size()] = &[0; Sha256.digest_size()];
+
+impl<'a> Default for TpmtHa<'a> {
+    fn default() -> Self {
+        Self::Sha256(EMPTY_SHA256)
     }
 }
-impl<'a, 'src: 'a> Unmarshal<'src> for TpmtHa<'a> {
-    fn unmarshal(
-        &mut self,
-        limits: impl Limits,
-        buf: &'src [u8],
-    ) -> Result<&'src [u8], UnmarshalError> {
-        let (arr, buf) = buf.split_first_chunk().ok_or(UnmarshalError)?;
 
-        match TpmiAlgHash::unmarshal_array(arr)? {
-            TpmiAlgHash::Sha1 if limits.supports_hash(Sha1) => {
-                let (arr, buf) = buf.split_first_chunk().ok_or(UnmarshalError)?;
-                *self = Self::Sha1(arr);
-                Ok(buf)
-            }
-            TpmiAlgHash::Sha256 if limits.supports_hash(Sha256) => {
-                let (arr, buf) = buf.split_first_chunk().ok_or(UnmarshalError)?;
-                *self = Self::Sha256(arr);
-                Ok(buf)
-            }
-            TpmiAlgHash::Sha384 if limits.supports_hash(Sha384) => {
-                let (arr, buf) = buf.split_first_chunk().ok_or(UnmarshalError)?;
-                *self = Self::Sha384(arr);
-                Ok(buf)
-            }
-            TpmiAlgHash::Sha512 if limits.supports_hash(Sha512) => {
-                let (arr, buf) = buf.split_first_chunk().ok_or(UnmarshalError)?;
-                *self = Self::Sha512(arr);
-                Ok(buf)
-            }
+// *** Marshal/Unmarshal implementations ***
+
+impl<'a> Marshal for TpmtHa<'a> {
+    const MAX_SIZE: usize = Alg::MAX_SIZE + TpmiAlgHash::MAX_DIGEST_SIZE;
+    type MaxBuffer = [u8; TpmtHa::MAX_SIZE];
+
+    fn marshal(&self, dst: &mut [u8; TpmtHa::MAX_SIZE]) -> usize {
+        let hash_alg = Alg::from(self.hash_alg());
+        let len = hash_alg.marshal((&mut dst[..Alg::MAX_SIZE]).try_into().unwrap());
+        let digest = self.digest();
+        dst[len..len + digest.len()].copy_from_slice(digest);
+        len + digest.len()
+    }
+}
+
+impl<'a> Unmarshal<'a> for TpmtHa<'a> {
+    fn unmarshal(src: &mut &'a [u8]) -> Result<Self, UnmarshalError> {
+        let alg = TpmiAlgHash::unmarshal(src)?;
+        match alg {
+            TpmiAlgHash::Sha1 => Ok(TpmtHa::Sha1(unmarshal_array_ref(src)?)),
+            TpmiAlgHash::Sha256 => Ok(TpmtHa::Sha256(unmarshal_array_ref(src)?)),
+            TpmiAlgHash::Sha384 => Ok(TpmtHa::Sha384(unmarshal_array_ref(src)?)),
+            TpmiAlgHash::Sha512 => Ok(TpmtHa::Sha512(unmarshal_array_ref(src)?)),
             _ => Err(UnmarshalError),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tpmt_ha_marshal_unmarshal() {
+        let digest_bytes = [0xAB; 32];
+        let tpmt_ha = TpmtHa::Sha256(&digest_bytes);
+
+        let mut buf = [0u8; TpmtHa::MAX_SIZE];
+        let len = tpmt_ha.marshal(&mut buf);
+        assert_eq!(len, 2 + 32);
+
+        let mut slice = &buf[..len];
+        let unmarshaled = TpmtHa::unmarshal(&mut slice).unwrap();
+        assert_eq!(unmarshaled, tpmt_ha);
+        assert!(slice.is_empty());
     }
 }


### PR DESCRIPTION
Part 2 (of 3) of #215

Fixes #244 

Refactor trait implementations out of definition modules into a sub-module hierarchy and complete missing serialization logic for basic types and commands:

- Move `Marshal` and `Unmarshal` trait implementations for primitives, array references (`&'a [u8; N]`), and the big-endian `BE<T>` wrapper into `marshal.rs`.
- Decouple trait implementations from type definitions by creating dedicated sub-modules under `impls/` (`alg`, `commands`, `enums`, `newtypes`).
- Implement `Marshal` and `Unmarshal` for foundational structures: `TpmtHa<'a>`, `Tpm2b<'a, N>`, `GetRandom`, and `responses::GetRandom<'a>`.
- Convert `commands/responses.rs` into a module directory structure `commands/responses/mod.rs`.
- Add documentation comments and `#[doc(alias)]` annotations matching TPM2 specification nomenclature (`TPM2B_DIGEST`, `TPM2_GetRandom`, `GetRandom_In`, `GetRandom_Out`).