### PR TITLE
Update docs for tpm2 and tpm2_client crates.

### DIFF
--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -1,3 +1,9 @@
+//! # TPM2 Base Types and Structures
+//!
+//! <div class="warning">
+//! This code is unstable and there are no guarantees of stability at this time.
+//! </div>
+//!
 #![allow(dead_code, clippy::large_enum_variant)]
 #![forbid(unsafe_code)]
 #![no_std]

--- a/crates/tpm2-client/src/connection/mod.rs
+++ b/crates/tpm2-client/src/connection/mod.rs
@@ -1,13 +1,11 @@
-//! This module provides traits to communicate with a
-//! TPM via a particular medium. The top-level trait
-//! is [`Connection`].
+//! The connection module provides the top level [`Connection`] trait and
+//! common implementations (as submodules) of the trait.
 
 use core::error::Error;
 
-mod tcp;
-pub use tcp::*;
+pub mod tcp;
 
-/// Trait for communicating with a TPM.
+/// Common trait for communicating with a TPM.
 pub trait Connection {
     /// The type returned if [`Connection::transact`] fails.
     ///
@@ -15,9 +13,11 @@ pub trait Connection {
     /// connection itself. If the connection can never fail, this can be
     /// [`Infallible`](core::convert::Infallible).
     type Error: Error;
+
     /// Perform a command/response transaction with the TPM.
     ///
-    /// Returns a slice of the response containing the bytes that were written.
+    /// Returns a slice of the response containing the bytes that were returned
+    /// from the TPM.
     ///
     /// Note that even if the response contains a `TPM_RC` error, this method
     /// still returns `Ok(...)`. `Err` is only returned when we are unable to

--- a/crates/tpm2-client/src/connection/tcp.rs
+++ b/crates/tpm2-client/src/connection/tcp.rs
@@ -1,9 +1,10 @@
 //! A connection to the TCG TPM 2.0 Simulator over TCP.
 //!
-//! This module provides the [`TcpConnection`] struct, which implements the
-//! [`Connection`] trait for communicating with a TPM simulator. It also
-//! provides a [`TcpSimulator`] struct that manages the lifetime of a TPM
-//! simulator process and a connection to it.
+//! This module provides two types for communicating with the TPM over TCP:
+//!
+//! - The [`TcpConnection`] struct, which implements the [`Connection`] trait.
+//! - A [`TcpSimulator`] struct that manages the lifetime of a TPM simulator
+//!   process and a [`TcpConnection`] to it.
 #![cfg(feature = "connection-tcp")]
 extern crate std;
 
@@ -26,7 +27,7 @@ const SIMULATOR_DEFAULT_TPM_PORT: u16 = 2321;
 /// The default Platform port of the TPM simulator
 const SIMULATOR_DEFAULT_PLATFORM_PORT: u16 = 2322;
 
-/// A connection to a TPM over TCP, designed for use with the TCG TPM 2.0 Simulator.
+/// A TPM connection over TCP, designed for use with the TCG TPM 2.0 Simulator.
 ///
 /// This struct implements the [`Connection`] trait.
 #[derive(Debug)]
@@ -188,8 +189,8 @@ impl TcpConnection {
     ///
     /// # Errors
     ///
-    /// Returns an error if the communication with the Platform port fails or if the
-    /// response terminator is invalid.
+    /// Returns an error if the communication with the Platform port fails or if
+    /// the response terminator is invalid.
     pub fn platform_signal(&mut self, signal: SimulatorPlatformSignal) -> Result<()> {
         let cmd_code = U32::new(signal as u32);
         self.plat_tcp.write_all(cmd_code.as_bytes())?;
@@ -215,8 +216,8 @@ impl TcpConnection {
     ///
     /// # Errors
     ///
-    /// Returns an error if the communication with the Platform port fails or if the
-    /// response terminator is invalid.
+    /// Returns an error if the communication with the Platform port fails or if
+    /// the response terminator is invalid.
     pub fn test_failure_mode(&mut self) -> Result<()> {
         let cmd_code = U32::new(SimulatorPlatformCommandCode::TestFailureMode as u32);
         self.plat_tcp.write_all(cmd_code.as_bytes())?;
@@ -229,8 +230,8 @@ impl TcpConnection {
     ///
     /// # Errors
     ///
-    /// Returns an error if the communication with the Platform port fails or if the
-    /// response terminator is invalid.
+    /// Returns an error if the communication with the Platform port fails or if
+    /// the response terminator is invalid.
     pub fn get_command_response_sizes(&mut self) -> Result<GetCommandResponseSizesResponse> {
         let cmd_code = U32::new(SimulatorPlatformCommandCode::GetCommandResponseSizes as u32);
         self.plat_tcp.write_all(cmd_code.as_bytes())?;
@@ -258,8 +259,8 @@ impl TcpConnection {
     ///
     /// # Errors
     ///
-    /// Returns an error if the communication with the Platform port fails or if the
-    /// response terminator is invalid.
+    /// Returns an error if the communication with the Platform port fails or if
+    /// the response terminator is invalid.
     pub fn act_get_signaled(&mut self, act_handle: u32) -> Result<u32> {
         let cmd_code = U32::new(SimulatorPlatformCommandCode::ActGetSignaled as u32);
         let cmd_payload = &ActGetSignaledRequest {
@@ -289,8 +290,8 @@ impl TcpConnection {
     ///
     /// # Errors
     ///
-    /// Returns an error if the communication with the Platform port fails or if the
-    /// response terminator is invalid.
+    /// Returns an error if the communication with the Platform port fails or if
+    /// the response terminator is invalid.
     pub fn set_firmware_hash(&mut self, hash: u32) -> Result<()> {
         let cmd_code = U32::new(SimulatorPlatformCommandCode::SetFirmwareHash as u32);
         let cmd_payload = &SetFirmwareHashRequest {
@@ -315,8 +316,8 @@ impl TcpConnection {
     ///
     /// # Errors
     ///
-    /// Returns an error if the communication with the Platform port fails or if the
-    /// response terminator is invalid.
+    /// Returns an error if the communication with the Platform port fails or if
+    /// the response terminator is invalid.
     pub fn set_firmware_svn(&mut self, svn: u32) -> Result<()> {
         let cmd_code = U32::new(SimulatorPlatformCommandCode::SetFirmwareSvn as u32);
         let cmd_payload = &SetFirmwareSvnRequest { svn: U32::new(svn) };
@@ -345,7 +346,8 @@ impl TcpConnection {
     ///
     /// # Errors
     ///
-    /// Returns an error if the communication with the TPM or Platform port fails.
+    /// Returns an error if the communication with the TPM or Platform port
+    /// fails.
     pub fn session_end(&mut self) -> Result<()> {
         let cmd_code = U32::new(SimulatorTpmCommandCode::SessionEnd as u32);
         self.tpm_tcp.write_all(cmd_code.as_bytes())?;
@@ -362,7 +364,8 @@ impl TcpConnection {
     ///
     /// # Errors
     ///
-    /// Returns an error if the communication with the TPM or Platform port fails.
+    /// Returns an error if the communication with the TPM or Platform port
+    /// fails.
     pub fn stop_simulator(&mut self) -> Result<()> {
         let cmd_code = U32::new(SimulatorTpmCommandCode::Stop as u32);
         self.tpm_tcp.write_all(cmd_code.as_bytes())?;
@@ -620,7 +623,8 @@ struct SetFirmwareSvnRequest {
     svn: U32,
 }
 
-/// Structure to manage the subprocess used to spawn the TPM simulator.
+/// Structure to manage the subprocess used to spawn the TPM simulator and a
+/// connection to it.
 #[derive(Debug)]
 pub struct TcpSimulator {
     child: Child,
@@ -628,7 +632,8 @@ pub struct TcpSimulator {
 }
 
 impl TcpSimulator {
-    /// Starts the TPM simulator binary with the given arguments and connects to it.
+    /// Starts the TPM simulator binary with the given arguments and connects to
+    /// it.
     pub fn new<B: AsRef<OsStr>, A: AsRef<OsStr>, P: AsRef<Path>>(
         bin: B,
         args: &[A],

--- a/crates/tpm2-client/src/lib.rs
+++ b/crates/tpm2-client/src/lib.rs
@@ -1,55 +1,51 @@
+//! # Trusted Platform Module 2.0 (TPM2) Client Library
+//!
+//! <div class="warning">
+//! This code is unstable and there are no guarantees of stability at this time.
+//! </div>
+//!
+//! This client crate provides:
+//!   - A [`Connection`] trait for communicating with a TPM
+//!   - Various structs implementing [`Connection`] for specific transports.
+//!   - High-level abstractions for building and sending commands over the
+//!     interface.
+//!
+//! ## Example
+//!
+//! ```rust,no_run
+//! use tpm2_client::{run_command, connection::tcp::TcpConnection};
+//! use tpm2_rs_base::commands::GetRandomCmd;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut tpm = TcpConnection::connect("127.0.0.1", None, None)?;
+//! let cmd = GetRandomCmd{ bytes_requested: 16 };
+//! let resp = run_command(&cmd, &mut tpm)?;
+//! # Ok(())
+//! # }
+//! ```
 #![forbid(unsafe_code)]
 #![no_std]
 
 use connection::Connection;
-use core::mem::size_of;
+use protocol::*;
 use sessions::{AuthorizationArea, Session};
 use tpm2_rs_base::commands::*;
-use tpm2_rs_base::constants::{TpmCc, TpmSt};
-use tpm2_rs_base::errors::{TssError, TssResult, TssTcsError};
+use tpm2_rs_base::constants::TpmSt;
+use tpm2_rs_base::errors::{TssError, TssTcsError};
 use tpm2_rs_base::marshal::{Marshalable, UnmarshalBuf};
-use tpm2_rs_base::{TpmiStCommandTag, TpmsAuthResponse};
 
 pub mod connection;
+pub mod protocol;
 pub mod sessions;
 
-pub const CMD_BUFFER_SIZE: usize = 4096;
-pub const RESP_BUFFER_SIZE: usize = 4096;
-
-pub fn get_capability<T: Connection<Error: From<TssError>>>(
-    tpm: &mut T,
-    command: &GetCapabilityCmd,
-) -> Result<GetCapabilityResp, T::Error> {
-    run_command(command, tpm)
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Marshalable)]
-pub struct CmdHeader {
-    tag: TpmiStCommandTag,
-    size: u32,
-    code: TpmCc,
-}
-impl CmdHeader {
-    fn new(has_sessions: bool, code: TpmCc) -> CmdHeader {
-        let tag = if has_sessions {
-            TpmiStCommandTag::NoSessions
-        } else {
-            TpmiStCommandTag::Sessions
-        };
-        CmdHeader { tag, size: 0, code }
-    }
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Marshalable)]
-pub struct RespHeader {
-    pub tag: TpmSt,
-    pub size: u32,
-    pub rc: u32,
-}
-
-/// Runs a command with default/unset handles.
+/// Runs a TPM command without sessions or handles over the given connectino.
+///
+/// # Errors
+/// Returns an error when marshaling, the underlying transaction on the
+/// connection, or unmarshaling the response fails.
+///
+/// Note that a `TPM_RC` error in the response header does not translate to an
+/// error in this function.
 pub fn run_command<CmdT: TpmCommand, T: Connection<Error: From<TssError>>>(
     cmd: &CmdT,
     tpm: &mut T,
@@ -57,88 +53,15 @@ pub fn run_command<CmdT: TpmCommand, T: Connection<Error: From<TssError>>>(
     Ok(run_command_with_handles(cmd, CmdT::Handles::default(), (), tpm)?.0)
 }
 
-/// This function serializes the size of the authorization area. `buffer` should
-/// point to the beginning of the authorization area, specifically to the location
-/// where the size of the authorization area will be serialized. The `auth_offset`
-/// indicates the offset to the end of the authorization area. The size to be
-/// serialized is calculated as the difference between the offset and the start
-/// of the buffer, excluding the size of the integer used to store the size.
-fn marshal_auth_size(auth_offset: usize, buffer: &mut [u8]) -> TssResult<usize> {
-    let auth_size = (auth_offset - size_of::<u32>()) as u32;
-    auth_size.try_marshal(buffer)?;
-    Ok(auth_offset)
-}
-
-/// Adds any command sessions to the command buffer.
-pub fn write_command_sessions<
-    X: Session,
-    Y: Session,
-    Z: Session,
-    AA: AuthorizationArea<X, Y, Z>,
->(
-    sessions: &AA,
-    buffer: &mut [u8],
-) -> TssResult<usize> {
-    if sessions.is_empty() {
-        return Ok(0);
-    }
-    let mut auth_offset = size_of::<u32>();
-    let (s1, s2, s3) = sessions.decompose_ref();
-    let Some(s1) = s1 else {
-        return marshal_auth_size(auth_offset, buffer);
-    };
-    auth_offset += s1
-        .get_auth_command()
-        .try_marshal(&mut buffer[auth_offset..])?;
-    let Some(s2) = s2 else {
-        return marshal_auth_size(auth_offset, buffer);
-    };
-    auth_offset += s2
-        .get_auth_command()
-        .try_marshal(&mut buffer[auth_offset..])?;
-    let Some(s3) = s3 else {
-        return marshal_auth_size(auth_offset, buffer);
-    };
-    auth_offset += s3
-        .get_auth_command()
-        .try_marshal(&mut buffer[auth_offset..])?;
-    marshal_auth_size(auth_offset, buffer)
-}
-
-/// Umarshals the response header and checks the contained response code.
-pub fn read_response_header(buffer: &[u8]) -> TssResult<(RespHeader, usize)> {
-    let mut unmarsh = UnmarshalBuf::new(buffer);
-    let resp_header = RespHeader::try_unmarshal(&mut unmarsh)?;
-    if let Ok(error) = TssError::try_from(resp_header.rc) {
-        return TssResult::Err(error);
-    }
-    Ok((resp_header, buffer.len() - unmarsh.len()))
-}
-
-/// Unmarshals any response sessions.
-pub fn read_response_sessions<
-    X: Session,
-    Y: Session,
-    Z: Session,
-    AA: AuthorizationArea<X, Y, Z>,
->(
-    sessions: &AA,
-    buffer: &mut UnmarshalBuf,
-) -> TssResult<()> {
-    let (s1, s2, s3) = sessions.decompose_ref();
-    let Some(s1) = s1 else { return Ok(()) };
-    let auth = TpmsAuthResponse::try_unmarshal(buffer)?;
-    s1.validate_auth_response(&auth)?;
-    let Some(s2) = s2 else { return Ok(()) };
-    let auth = TpmsAuthResponse::try_unmarshal(buffer)?;
-    s2.validate_auth_response(&auth)?;
-    let Some(s3) = s3 else { return Ok(()) };
-    let auth = TpmsAuthResponse::try_unmarshal(buffer)?;
-    s3.validate_auth_response(&auth)?;
-    Ok(())
-}
-
-/// Runs a command with provided handles and sessions.
+/// Runs a TPM command with the provided handles and sessions over the given
+/// connectino.
+///
+/// # Errors
+/// Returns an error when marshaling, the underlying transaction on the
+/// connection, or unmarshaling the response fails.
+///
+/// Note that a `TPM_RC` error in the response header does not translate to an
+/// error in this function.
 pub fn run_command_with_handles<
     CmdT: TpmCommand,
     T: Connection<Error: From<TssError>>,

--- a/crates/tpm2-client/src/protocol/mod.rs
+++ b/crates/tpm2-client/src/protocol/mod.rs
@@ -1,0 +1,128 @@
+//! Low-level TPM 2.0 protocol structures and utility functions.
+
+use crate::sessions::{AuthorizationArea, Session};
+use core::mem::size_of;
+use tpm2_rs_base::constants::{TpmCc, TpmSt};
+use tpm2_rs_base::errors::{TssError, TssResult};
+use tpm2_rs_base::marshal::{Marshalable, UnmarshalBuf};
+use tpm2_rs_base::{TpmiStCommandTag, TpmsAuthResponse};
+
+/// Maximum buffer size for sending TPM commands.
+pub const CMD_BUFFER_SIZE: usize = 4096;
+
+/// Maximum buffer size for receiving TPM responses.
+pub const RESP_BUFFER_SIZE: usize = 4096;
+
+/// TPM 2.0 Command Header
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Marshalable)]
+pub struct CmdHeader {
+    /// Command tag indicating session usage (`TPM_ST_NO_SESSIONS` or `TPM_ST_SESSIONS`).
+    pub tag: TpmiStCommandTag,
+    /// Total size in bytes of the command including this header.
+    pub size: u32,
+    /// Command code (`TPM_CC`).
+    pub code: TpmCc,
+}
+impl CmdHeader {
+    pub fn new(has_sessions: bool, code: TpmCc) -> CmdHeader {
+        let tag = if has_sessions {
+            TpmiStCommandTag::NoSessions
+        } else {
+            TpmiStCommandTag::Sessions
+        };
+        CmdHeader { tag, size: 0, code }
+    }
+}
+
+/// TPM 2.0 Response Header
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Marshalable)]
+pub struct RespHeader {
+    /// Response tag which matches the corresponding tag in the command.
+    pub tag: TpmSt,
+    /// Total size in bytes of the response including this header.
+    pub size: u32,
+    /// Response code (`TPM_RC`).
+    pub rc: u32,
+}
+
+/// Marshals the auth_size parameter of the session area into the given
+/// `buffer`, which should point to the beginning of the session area.
+/// `auth_offset` indicates the offset to the end of the authorization area
+fn marshal_auth_size(auth_offset: usize, buffer: &mut [u8]) -> TssResult<usize> {
+    let auth_size = (auth_offset - size_of::<u32>()) as u32;
+    auth_size.try_marshal(buffer)?;
+    Ok(auth_offset)
+}
+
+/// Marshals the session area (u32 size + 0-3 `TPMS_AUTH_COMMAND` structs) into
+/// the given buffer, returning the number of bytes that were marshaled.
+pub fn write_command_sessions<
+    X: Session,
+    Y: Session,
+    Z: Session,
+    AA: AuthorizationArea<X, Y, Z>,
+>(
+    sessions: &AA,
+    buffer: &mut [u8],
+) -> TssResult<usize> {
+    if sessions.is_empty() {
+        return Ok(0);
+    }
+    let mut auth_offset = size_of::<u32>();
+    let (s1, s2, s3) = sessions.decompose_ref();
+    let Some(s1) = s1 else {
+        return marshal_auth_size(auth_offset, buffer);
+    };
+    auth_offset += s1
+        .get_auth_command()
+        .try_marshal(&mut buffer[auth_offset..])?;
+    let Some(s2) = s2 else {
+        return marshal_auth_size(auth_offset, buffer);
+    };
+    auth_offset += s2
+        .get_auth_command()
+        .try_marshal(&mut buffer[auth_offset..])?;
+    let Some(s3) = s3 else {
+        return marshal_auth_size(auth_offset, buffer);
+    };
+    auth_offset += s3
+        .get_auth_command()
+        .try_marshal(&mut buffer[auth_offset..])?;
+    marshal_auth_size(auth_offset, buffer)
+}
+
+/// Unmarshals the response header from the given `buffer`.
+pub fn read_response_header(buffer: &[u8]) -> TssResult<(RespHeader, usize)> {
+    let mut unmarsh = UnmarshalBuf::new(buffer);
+    let resp_header = RespHeader::try_unmarshal(&mut unmarsh)?;
+    if let Ok(error) = TssError::try_from(resp_header.rc) {
+        return TssResult::Err(error);
+    }
+    Ok((resp_header, buffer.len() - unmarsh.len()))
+}
+
+/// Unmarshals the session area (0-3 `TPMS_AUTH_RESPONSE` structs) from the
+/// given `buffer`.
+pub fn read_response_sessions<
+    X: Session,
+    Y: Session,
+    Z: Session,
+    AA: AuthorizationArea<X, Y, Z>,
+>(
+    sessions: &AA,
+    buffer: &mut UnmarshalBuf,
+) -> TssResult<()> {
+    let (s1, s2, s3) = sessions.decompose_ref();
+    let Some(s1) = s1 else { return Ok(()) };
+    let auth = TpmsAuthResponse::try_unmarshal(buffer)?;
+    s1.validate_auth_response(&auth)?;
+    let Some(s2) = s2 else { return Ok(()) };
+    let auth = TpmsAuthResponse::try_unmarshal(buffer)?;
+    s2.validate_auth_response(&auth)?;
+    let Some(s3) = s3 else { return Ok(()) };
+    let auth = TpmsAuthResponse::try_unmarshal(buffer)?;
+    s3.validate_auth_response(&auth)?;
+    Ok(())
+}

--- a/crates/tpm2-client/src/tests.rs
+++ b/crates/tpm2-client/src/tests.rs
@@ -1,9 +1,9 @@
 use crate::sessions::{PasswordSession, Session};
 
 use super::*;
-use tpm2_rs_base::TpmaSession;
-use tpm2_rs_base::constants::TpmHandle;
-use tpm2_rs_base::errors::TpmRcError;
+use tpm2_rs_base::constants::{TpmCc, TpmHandle};
+use tpm2_rs_base::errors::{TpmRcError, TssResult};
+use tpm2_rs_base::{TpmaSession, TpmsAuthResponse};
 
 // A Tpm that just returns a general failure error.
 struct ErrorTpm();

--- a/crates/tpm2-client/tests/simulator.rs
+++ b/crates/tpm2-client/tests/simulator.rs
@@ -11,7 +11,7 @@ use std::io::Result;
 use std::net::Ipv4Addr;
 
 use tempfile::tempdir;
-use tpm2_client::connection::TcpSimulator;
+use tpm2_client::connection::tcp::TcpSimulator;
 use tpm2_client::run_command;
 use tpm2_rs_base::commands::StartupCmd;
 use tpm2_rs_base::constants::TpmSu;

--- a/crates/tpm2-impl/src/lib.rs
+++ b/crates/tpm2-impl/src/lib.rs
@@ -1,3 +1,9 @@
+//! # TPM2 Implementation Core
+//!
+//! <div class="warning">
+//! This code is unstable and there are no guarantees of stability at this time.
+//! </div>
+//!
 #![no_std]
 #![forbid(unsafe_code)]
 #![allow(dead_code)] // rustc >= 1.90.0 (1159e78c4 2025-09-14)

--- a/crates/tpm2/src/lib.rs
+++ b/crates/tpm2/src/lib.rs
@@ -1,5 +1,9 @@
 //! # Trusted Platform Module 2.0 (TPM2) Structures and Commands
 //!
+//! <div class="warning">
+//! This code is unstable and there are no guarantees of stability at this time.
+//! </div>
+//!
 //! This base crate provides:
 //!   - Definitions of the TPM2 constants and structures.
 //!   - Definitions of the [TPM2 Commands](commands).
@@ -20,8 +24,6 @@
 //! Conversely, types or items that either do not map to a type in the spec
 //! (e.g., [`Marshal`] or [`Command`]) or have semantics differing from those in
 //! the spec (e.g., [`Alg`]) will not have a `Tpm` prefix.
-//!
-//! will not have a `Tpm` prefix.
 //!
 //! [TPM2 Specification]: https://trustedcomputinggroup.org/work-groups/trusted-platform-module/
 //!

--- a/marshalable-derive/src/lib.rs
+++ b/marshalable-derive/src/lib.rs
@@ -1,3 +1,9 @@
+//! # Proc-macro Derive for TPM2 Marshalable
+//!
+//! <div class="warning">
+//! This code is unstable and there are no guarantees of stability at this time.
+//! </div>
+//!
 #![forbid(unsafe_code)]
 
 use proc_macro2::{Span, TokenStream};

--- a/marshalable/src/lib.rs
+++ b/marshalable/src/lib.rs
@@ -1,3 +1,9 @@
+//! # TPM2 Marshalable Trait & Utilities
+//!
+//! <div class="warning">
+//! This code is unstable and there are no guarantees of stability at this time.
+//! </div>
+//!
 #![forbid(unsafe_code)]
 #![no_std]
 


### PR DESCRIPTION
- Add documentation where missing
- Format to wrap to 80 characters
- Move some tpm2_client code into a protocol module to clean up the organization of the docs.