### PR TITLE
Fix API naming violations and getter conventions in tpm2 and tpm2-cli…

### DIFF
--- a/crates/tpm2-client/src/connection/tcp.rs
+++ b/crates/tpm2-client/src/connection/tcp.rs
@@ -232,7 +232,7 @@ impl TcpConnection {
     ///
     /// Returns an error if the communication with the Platform port fails or if
     /// the response terminator is invalid.
-    pub fn get_command_response_sizes(&mut self) -> Result<GetCommandResponseSizesResponse> {
+    pub fn command_response_sizes(&mut self) -> Result<GetCommandResponseSizesResponse> {
         let cmd_code = U32::new(SimulatorPlatformCommandCode::GetCommandResponseSizes as u32);
         self.plat_tcp.write_all(cmd_code.as_bytes())?;
 
@@ -261,7 +261,7 @@ impl TcpConnection {
     ///
     /// Returns an error if the communication with the Platform port fails or if
     /// the response terminator is invalid.
-    pub fn act_get_signaled(&mut self, act_handle: u32) -> Result<u32> {
+    pub fn act_signaled(&mut self, act_handle: u32) -> Result<u32> {
         let cmd_code = U32::new(SimulatorPlatformCommandCode::ActGetSignaled as u32);
         let cmd_payload = &ActGetSignaledRequest {
             act_handle: U32::new(act_handle),

--- a/crates/tpm2-client/src/lib.rs
+++ b/crates/tpm2-client/src/lib.rs
@@ -76,7 +76,7 @@ pub fn run_command_with_handles<
     tpm: &mut T,
 ) -> Result<(CmdT::RespT, CmdT::RespHandles), T::Error> {
     let mut cmd_buffer = [0u8; CMD_BUFFER_SIZE];
-    let mut cmd_header = CmdHeader::new(cmd_sessions.is_empty(), CmdT::CMD_CODE);
+    let mut cmd_header = CmdHeader::new(!cmd_sessions.is_empty(), CmdT::CMD_CODE);
     let mut written = cmd_header
         .try_marshal(&mut cmd_buffer)
         .map_err(TssError::from)?;

--- a/crates/tpm2-client/src/protocol/mod.rs
+++ b/crates/tpm2-client/src/protocol/mod.rs
@@ -27,9 +27,9 @@ pub struct CmdHeader {
 impl CmdHeader {
     pub fn new(has_sessions: bool, code: TpmCc) -> CmdHeader {
         let tag = if has_sessions {
-            TpmiStCommandTag::NoSessions
-        } else {
             TpmiStCommandTag::Sessions
+        } else {
+            TpmiStCommandTag::NoSessions
         };
         CmdHeader { tag, size: 0, code }
     }
@@ -75,21 +75,15 @@ pub fn write_command_sessions<
     let Some(s1) = s1 else {
         return marshal_auth_size(auth_offset, buffer);
     };
-    auth_offset += s1
-        .get_auth_command()
-        .try_marshal(&mut buffer[auth_offset..])?;
+    auth_offset += s1.auth_command().try_marshal(&mut buffer[auth_offset..])?;
     let Some(s2) = s2 else {
         return marshal_auth_size(auth_offset, buffer);
     };
-    auth_offset += s2
-        .get_auth_command()
-        .try_marshal(&mut buffer[auth_offset..])?;
+    auth_offset += s2.auth_command().try_marshal(&mut buffer[auth_offset..])?;
     let Some(s3) = s3 else {
         return marshal_auth_size(auth_offset, buffer);
     };
-    auth_offset += s3
-        .get_auth_command()
-        .try_marshal(&mut buffer[auth_offset..])?;
+    auth_offset += s3.auth_command().try_marshal(&mut buffer[auth_offset..])?;
     marshal_auth_size(auth_offset, buffer)
 }
 

--- a/crates/tpm2-client/src/sessions/nosession.rs
+++ b/crates/tpm2-client/src/sessions/nosession.rs
@@ -16,7 +16,7 @@ impl Session for NoSession {
         // replace it with a loop {}.
         unreachable!()
     }
-    fn get_auth_command(&self) -> TpmsAuthCommand {
+    fn auth_command(&self) -> TpmsAuthCommand {
         unreachable!()
     }
 }

--- a/crates/tpm2-client/src/sessions/password.rs
+++ b/crates/tpm2-client/src/sessions/password.rs
@@ -14,8 +14,8 @@ use tpm2_rs_base::{
 /// let password1 = PasswordSession::new("hello world").unwrap(); // from a string
 /// let password2 = PasswordSession::new(&[1, 2, 3, 4, 5, 6]).unwrap(); // from a byte array
 ///
-/// assert_eq!(password1.get_secret(), b"hello world");
-/// assert_eq!(password2.get_secret(), &[1, 2, 3, 4, 5, 6]);
+/// assert_eq!(password1.secret(), b"hello world");
+/// assert_eq!(password2.secret(), &[1, 2, 3, 4, 5, 6]);
 /// ```
 #[derive(Debug, PartialEq, Default)]
 pub struct PasswordSession {
@@ -46,13 +46,13 @@ impl PasswordSession {
         })
     }
     /// This function returns the data(password) stored inside a password session
-    pub fn get_secret(&self) -> &[u8] {
+    pub fn secret(&self) -> &[u8] {
         self.auth.get_buffer()
     }
 }
 
 impl Session for PasswordSession {
-    fn get_auth_command(&self) -> TpmsAuthCommand {
+    fn auth_command(&self) -> TpmsAuthCommand {
         TpmsAuthCommand {
             session_handle: TpmiShAuthSession::RS_PW,
             nonce: Tpm2bNonce::default(),

--- a/crates/tpm2-client/src/sessions/session.rs
+++ b/crates/tpm2-client/src/sessions/session.rs
@@ -3,7 +3,7 @@ use tpm2_rs_base::{TpmsAuthCommand, TpmsAuthResponse, errors::TssResult};
 /// Trait for types representing TPM sessions.
 pub trait Session {
     /// Computes the authorization HMAC for this session.
-    fn get_auth_command(&self) -> TpmsAuthCommand;
+    fn auth_command(&self) -> TpmsAuthCommand;
     /// Validates the authorization response for this session.
     fn validate_auth_response(&self, auth: &TpmsAuthResponse) -> TssResult<()>;
 }

--- a/crates/tpm2-client/src/sessions/tests.rs
+++ b/crates/tpm2-client/src/sessions/tests.rs
@@ -3,9 +3,9 @@ use tpm2_rs_base::{Tpm2bSimple, TpmiShAuthSession};
 use super::*;
 
 #[test]
-fn test_password_get_auth_command() {
+fn test_password_auth_command() {
     let session = PasswordSession::new("hello").unwrap();
-    let tpm_auth = session.get_auth_command();
+    let tpm_auth = session.auth_command();
     assert_eq!(tpm_auth.session_handle, TpmiShAuthSession::RS_PW);
     assert_eq!(tpm_auth.hmac.get_size(), 5);
     assert_eq!(tpm_auth.hmac.get_buffer(), b"hello");

--- a/crates/tpm2/src/errors/tpm_rc/mod.rs
+++ b/crates/tpm2/src/errors/tpm_rc/mod.rs
@@ -20,8 +20,7 @@ impl TpmRcError {
 
     /// Asymmetric algorithm not supported or not correct for the specified
     /// parameters (`TPM_RC_ASYMMETRIC`).
-    #[allow(non_snake_case)]
-    pub const fn AsymmetricFor(on: ErrorType, pos: ErrorPosition) -> Self {
+    pub const fn asymmetric_for(on: ErrorType, pos: ErrorPosition) -> Self {
         Self::new(Self::Asymmetric.0.get() | on.to_mask() | pos.to_mask())
     }
 
@@ -30,8 +29,7 @@ impl TpmRcError {
 
     /// Value is out of range or is not correct for the context for the specified
     /// parameters (`TPM_RC_VALUE`).
-    #[allow(non_snake_case)]
-    pub const fn ValueFor(on: ErrorType, pos: ErrorPosition) -> Self {
+    pub const fn value_for(on: ErrorType, pos: ErrorPosition) -> Self {
         Self::new(Self::Value.0.get() | on.to_mask() | pos.to_mask())
     }
 
@@ -39,8 +37,7 @@ impl TpmRcError {
     pub const Size: Self = Self::new(Self::RC_FMT1 + 0x015);
 
     /// Structure is the wrong size for the specified parameters (`TPM_RC_SIZE`).
-    #[allow(non_snake_case)]
-    pub const fn SizeFor(on: ErrorType, pos: ErrorPosition) -> Self {
+    pub const fn size_for(on: ErrorType, pos: ErrorPosition) -> Self {
         Self::new(Self::Size.0.get() | on.to_mask() | pos.to_mask())
     }
 
@@ -48,8 +45,7 @@ impl TpmRcError {
     pub const Selector: Self = Self::new(Self::RC_FMT1 + 0x018);
 
     /// Union selector is incorrect for the specified parameters (`TPM_RC_SELECTOR`).
-    #[allow(non_snake_case)]
-    pub const fn SelectorFor(on: ErrorType, pos: ErrorPosition) -> Self {
+    pub const fn selector_for(on: ErrorType, pos: ErrorPosition) -> Self {
         Self::new(Self::Selector.0.get() | on.to_mask() | pos.to_mask())
     }
 

--- a/crates/tpm2/src/errors/tpm_rc/tests.rs
+++ b/crates/tpm2/src/errors/tpm_rc/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn test_format1() {
-    let error = TpmRcError::AsymmetricFor(ErrorType::Parameter, ErrorPosition::Pos2);
+    let error = TpmRcError::asymmetric_for(ErrorType::Parameter, ErrorPosition::Pos2);
     assert_eq!(error.get(), 0x2C1);
 
     let (on, pos) = error

--- a/crates/tpm2/src/errors/tss_rc.rs
+++ b/crates/tpm2/src/errors/tss_rc.rs
@@ -28,7 +28,7 @@ macro_rules! generate_tss_layer_error {
             pub const NotImplemented: Self = Self::new(6);
             /// Key could not be registered because UUID has already registered
             /// (`TSS_E_KEY_ALREADY_REGISTERED`).
-            pub const KeyAlredyRegistered: Self = Self::new(8);
+            pub const KeyAlreadyRegistered: Self = Self::new(8);
             /// TPM returns with success but TSP/TCS notice that something is wrong
             /// (`TSS_E_TPM_UNEXPECTED`).
             pub const TpmUnexpected: Self = Self::new(16);


### PR DESCRIPTION
…ent crates.

- Renamed TpmRcError constructors (AsymmetricFor -> asymmetric_for, ValueFor -> value_for, SizeFor -> size_for, SelectorFor -> selector_for).
- Fixed typo in KeyAlreadyRegistered constant name in tss_rc.
- Renamed get_auth_command to auth_command across Session trait and implementations.
- Renamed PasswordSession::get_secret to PasswordSession::secret.
- Renamed TcpConnection getters (get_command_response_sizes -> command_response_sizes, act_get_signaled -> act_signaled).
- Fixed boolean logic and parameter semantics in CmdHeader::new.