### PR TITLE
Implement standard error and interoperability traits across tpm2 and tpm2-client.

### DIFF
--- a/crates/tpm2-client/src/connection/tcp.rs
+++ b/crates/tpm2-client/src/connection/tcp.rs
@@ -232,7 +232,7 @@ impl TcpConnection {
     ///
     /// Returns an error if the communication with the Platform port fails or if
     /// the response terminator is invalid.
-    pub fn get_command_response_sizes(&mut self) -> Result<GetCommandResponseSizesResponse> {
+    pub fn command_response_sizes(&mut self) -> Result<GetCommandResponseSizesResponse> {
         let cmd_code = U32::new(SimulatorPlatformCommandCode::GetCommandResponseSizes as u32);
         self.plat_tcp.write_all(cmd_code.as_bytes())?;
 
@@ -261,7 +261,7 @@ impl TcpConnection {
     ///
     /// Returns an error if the communication with the Platform port fails or if
     /// the response terminator is invalid.
-    pub fn act_get_signaled(&mut self, act_handle: u32) -> Result<u32> {
+    pub fn act_signaled(&mut self, act_handle: u32) -> Result<u32> {
         let cmd_code = U32::new(SimulatorPlatformCommandCode::ActGetSignaled as u32);
         let cmd_payload = &ActGetSignaledRequest {
             act_handle: U32::new(act_handle),

--- a/crates/tpm2-client/src/connection/tcp.rs
+++ b/crates/tpm2-client/src/connection/tcp.rs
@@ -495,7 +495,7 @@ struct RemoteHandshakeRequest {
 
 /// Parameters for the RemoteHandshake response
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Default, FromBytes, IntoBytes, KnownLayout, Immutable,
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, FromBytes, IntoBytes, KnownLayout, Immutable,
 )]
 #[repr(C, packed)]
 pub struct RemoteHandshakeResponse {
@@ -515,7 +515,7 @@ impl RemoteHandshakeResponse {
 }
 
 /// A signal that can be sent to the Platform port of the TPM simulator
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u32)]
 pub enum SimulatorPlatformSignal {
     /// Signal that power is applied to the TPM.
@@ -566,7 +566,7 @@ enum SimulatorPlatformCommandCode {
 
 /// Parameters for the GetCommandResponseSizes response
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Default, FromBytes, IntoBytes, KnownLayout, Immutable,
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, FromBytes, IntoBytes, KnownLayout, Immutable,
 )]
 #[repr(C)]
 pub struct GetCommandResponseSizesResponse {

--- a/crates/tpm2-client/src/lib.rs
+++ b/crates/tpm2-client/src/lib.rs
@@ -76,7 +76,7 @@ pub fn run_command_with_handles<
     tpm: &mut T,
 ) -> Result<(CmdT::RespT, CmdT::RespHandles), T::Error> {
     let mut cmd_buffer = [0u8; CMD_BUFFER_SIZE];
-    let mut cmd_header = CmdHeader::new(cmd_sessions.is_empty(), CmdT::CMD_CODE);
+    let mut cmd_header = CmdHeader::new(!cmd_sessions.is_empty(), CmdT::CMD_CODE);
     let mut written = cmd_header
         .try_marshal(&mut cmd_buffer)
         .map_err(TssError::from)?;

--- a/crates/tpm2-client/src/protocol/mod.rs
+++ b/crates/tpm2-client/src/protocol/mod.rs
@@ -27,9 +27,9 @@ pub struct CmdHeader {
 impl CmdHeader {
     pub fn new(has_sessions: bool, code: TpmCc) -> CmdHeader {
         let tag = if has_sessions {
-            TpmiStCommandTag::NoSessions
-        } else {
             TpmiStCommandTag::Sessions
+        } else {
+            TpmiStCommandTag::NoSessions
         };
         CmdHeader { tag, size: 0, code }
     }
@@ -75,21 +75,15 @@ pub fn write_command_sessions<
     let Some(s1) = s1 else {
         return marshal_auth_size(auth_offset, buffer);
     };
-    auth_offset += s1
-        .get_auth_command()
-        .try_marshal(&mut buffer[auth_offset..])?;
+    auth_offset += s1.auth_command().try_marshal(&mut buffer[auth_offset..])?;
     let Some(s2) = s2 else {
         return marshal_auth_size(auth_offset, buffer);
     };
-    auth_offset += s2
-        .get_auth_command()
-        .try_marshal(&mut buffer[auth_offset..])?;
+    auth_offset += s2.auth_command().try_marshal(&mut buffer[auth_offset..])?;
     let Some(s3) = s3 else {
         return marshal_auth_size(auth_offset, buffer);
     };
-    auth_offset += s3
-        .get_auth_command()
-        .try_marshal(&mut buffer[auth_offset..])?;
+    auth_offset += s3.auth_command().try_marshal(&mut buffer[auth_offset..])?;
     marshal_auth_size(auth_offset, buffer)
 }
 

--- a/crates/tpm2-client/src/protocol/mod.rs
+++ b/crates/tpm2-client/src/protocol/mod.rs
@@ -15,7 +15,7 @@ pub const RESP_BUFFER_SIZE: usize = 4096;
 
 /// TPM 2.0 Command Header
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Marshalable)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default, Marshalable)]
 pub struct CmdHeader {
     /// Command tag indicating session usage (`TPM_ST_NO_SESSIONS` or `TPM_ST_SESSIONS`).
     pub tag: TpmiStCommandTag,
@@ -37,7 +37,7 @@ impl CmdHeader {
 
 /// TPM 2.0 Response Header
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Marshalable)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default, Marshalable)]
 pub struct RespHeader {
     /// Response tag which matches the corresponding tag in the command.
     pub tag: TpmSt,

--- a/crates/tpm2-client/src/sessions/nosession.rs
+++ b/crates/tpm2-client/src/sessions/nosession.rs
@@ -16,7 +16,7 @@ impl Session for NoSession {
         // replace it with a loop {}.
         unreachable!()
     }
-    fn get_auth_command(&self) -> TpmsAuthCommand {
+    fn auth_command(&self) -> TpmsAuthCommand {
         unreachable!()
     }
 }

--- a/crates/tpm2-client/src/sessions/password.rs
+++ b/crates/tpm2-client/src/sessions/password.rs
@@ -14,8 +14,8 @@ use tpm2_rs_base::{
 /// let password1 = PasswordSession::new("hello world").unwrap(); // from a string
 /// let password2 = PasswordSession::new(&[1, 2, 3, 4, 5, 6]).unwrap(); // from a byte array
 ///
-/// assert_eq!(password1.get_secret(), b"hello world");
-/// assert_eq!(password2.get_secret(), &[1, 2, 3, 4, 5, 6]);
+/// assert_eq!(password1.secret(), b"hello world");
+/// assert_eq!(password2.secret(), &[1, 2, 3, 4, 5, 6]);
 /// ```
 #[derive(Debug, PartialEq, Default)]
 pub struct PasswordSession {
@@ -46,13 +46,13 @@ impl PasswordSession {
         })
     }
     /// This function returns the data(password) stored inside a password session
-    pub fn get_secret(&self) -> &[u8] {
+    pub fn secret(&self) -> &[u8] {
         self.auth.get_buffer()
     }
 }
 
 impl Session for PasswordSession {
-    fn get_auth_command(&self) -> TpmsAuthCommand {
+    fn auth_command(&self) -> TpmsAuthCommand {
         TpmsAuthCommand {
             session_handle: TpmiShAuthSession::RS_PW,
             nonce: Tpm2bNonce::default(),

--- a/crates/tpm2-client/src/sessions/password.rs
+++ b/crates/tpm2-client/src/sessions/password.rs
@@ -17,7 +17,7 @@ use tpm2_rs_base::{
 /// assert_eq!(password1.secret(), b"hello world");
 /// assert_eq!(password2.secret(), &[1, 2, 3, 4, 5, 6]);
 /// ```
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub struct PasswordSession {
     auth: Tpm2bAuth,
 }

--- a/crates/tpm2-client/src/sessions/session.rs
+++ b/crates/tpm2-client/src/sessions/session.rs
@@ -3,7 +3,7 @@ use tpm2_rs_base::{TpmsAuthCommand, TpmsAuthResponse, errors::TssResult};
 /// Trait for types representing TPM sessions.
 pub trait Session {
     /// Computes the authorization HMAC for this session.
-    fn get_auth_command(&self) -> TpmsAuthCommand;
+    fn auth_command(&self) -> TpmsAuthCommand;
     /// Validates the authorization response for this session.
     fn validate_auth_response(&self, auth: &TpmsAuthResponse) -> TssResult<()>;
 }

--- a/crates/tpm2-client/src/sessions/tests.rs
+++ b/crates/tpm2-client/src/sessions/tests.rs
@@ -3,9 +3,9 @@ use tpm2_rs_base::{Tpm2bSimple, TpmiShAuthSession};
 use super::*;
 
 #[test]
-fn test_password_get_auth_command() {
+fn test_password_auth_command() {
     let session = PasswordSession::new("hello").unwrap();
-    let tpm_auth = session.get_auth_command();
+    let tpm_auth = session.auth_command();
     assert_eq!(tpm_auth.session_handle, TpmiShAuthSession::RS_PW);
     assert_eq!(tpm_auth.hmac.get_size(), 5);
     assert_eq!(tpm_auth.hmac.get_buffer(), b"hello");

--- a/crates/tpm2/src/commands/mod.rs
+++ b/crates/tpm2/src/commands/mod.rs
@@ -29,7 +29,7 @@ pub trait Command {
 ///
 /// Returns the next `bytesRequested` octets from the random number generator (RNG).
 #[doc(alias("TPM2_GetRandom", "GetRandom_In"))]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default, Debug)]
 pub struct GetRandom {
     pub bytes_requested: u16,
 }

--- a/crates/tpm2/src/commands/responses.rs
+++ b/crates/tpm2/src/commands/responses.rs
@@ -2,7 +2,7 @@ use crate::Tpm2bDigest;
 
 /// Random bytes retuned by the RNG
 #[doc(alias("GetRandom_Out"))]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default, Debug)]
 pub struct GetRandom<'a> {
     pub random_bytes: Tpm2bDigest<'a>,
 }

--- a/crates/tpm2/src/constants.rs
+++ b/crates/tpm2/src/constants.rs
@@ -9,7 +9,7 @@ use crate::{MarshalArray, UnmarshalArray};
 /// [TCG Algorithm Registry](https://trustedcomputinggroup.org/resource/tcg-algorithm-registry/).
 ///
 /// [TPM2 Specification]: https://trustedcomputinggroup.org/work-groups/trusted-platform-module/
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default, Debug)]
 #[repr(transparent)]
 pub struct Alg(pub u16);
 

--- a/crates/tpm2/src/errors/mod.rs
+++ b/crates/tpm2/src/errors/mod.rs
@@ -16,12 +16,28 @@ mod tpm_rc;
 mod tss_rc;
 
 /// Any error which can happen when marshalling
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct MarshalError;
 
+impl fmt::Display for MarshalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "marshal error")
+    }
+}
+
+impl Error for MarshalError {}
+
 /// Any error which can happen when unmarshalling
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct UnmarshalError;
+
+impl fmt::Display for UnmarshalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unmarshal error")
+    }
+}
+
+impl Error for UnmarshalError {}
 
 impl From<Infallible> for UnmarshalError {
     fn from(value: Infallible) -> Self {
@@ -30,8 +46,16 @@ impl From<Infallible> for UnmarshalError {
 }
 
 /// Specific error type corresponding to TPM_RC_HASH
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct HashError;
+
+impl fmt::Display for HashError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "hash error")
+    }
+}
+
+impl Error for HashError {}
 
 impl From<HashError> for UnmarshalError {
     fn from(_: HashError) -> Self {
@@ -62,8 +86,16 @@ impl fmt::Display for TssError {
 impl Error for TssError {}
 
 /// Error returned when trying to convert `0` into `TssError`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct TssErrorCannotBeZero;
+
+impl fmt::Display for TssErrorCannotBeZero {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TSS error cannot be zero")
+    }
+}
+
+impl Error for TssErrorCannotBeZero {}
 
 impl TryFrom<u32> for TssError {
     type Error = TssErrorCannotBeZero;

--- a/crates/tpm2/src/errors/tpm_rc/mod.rs
+++ b/crates/tpm2/src/errors/tpm_rc/mod.rs
@@ -20,8 +20,7 @@ impl TpmRcError {
 
     /// Asymmetric algorithm not supported or not correct for the specified
     /// parameters (`TPM_RC_ASYMMETRIC`).
-    #[allow(non_snake_case)]
-    pub const fn AsymmetricFor(on: ErrorType, pos: ErrorPosition) -> Self {
+    pub const fn asymmetric_for(on: ErrorType, pos: ErrorPosition) -> Self {
         Self::new(Self::Asymmetric.0.get() | on.to_mask() | pos.to_mask())
     }
 
@@ -30,8 +29,7 @@ impl TpmRcError {
 
     /// Value is out of range or is not correct for the context for the specified
     /// parameters (`TPM_RC_VALUE`).
-    #[allow(non_snake_case)]
-    pub const fn ValueFor(on: ErrorType, pos: ErrorPosition) -> Self {
+    pub const fn value_for(on: ErrorType, pos: ErrorPosition) -> Self {
         Self::new(Self::Value.0.get() | on.to_mask() | pos.to_mask())
     }
 
@@ -39,8 +37,7 @@ impl TpmRcError {
     pub const Size: Self = Self::new(Self::RC_FMT1 + 0x015);
 
     /// Structure is the wrong size for the specified parameters (`TPM_RC_SIZE`).
-    #[allow(non_snake_case)]
-    pub const fn SizeFor(on: ErrorType, pos: ErrorPosition) -> Self {
+    pub const fn size_for(on: ErrorType, pos: ErrorPosition) -> Self {
         Self::new(Self::Size.0.get() | on.to_mask() | pos.to_mask())
     }
 
@@ -48,8 +45,7 @@ impl TpmRcError {
     pub const Selector: Self = Self::new(Self::RC_FMT1 + 0x018);
 
     /// Union selector is incorrect for the specified parameters (`TPM_RC_SELECTOR`).
-    #[allow(non_snake_case)]
-    pub const fn SelectorFor(on: ErrorType, pos: ErrorPosition) -> Self {
+    pub const fn selector_for(on: ErrorType, pos: ErrorPosition) -> Self {
         Self::new(Self::Selector.0.get() | on.to_mask() | pos.to_mask())
     }
 

--- a/crates/tpm2/src/errors/tpm_rc/mod.rs
+++ b/crates/tpm2/src/errors/tpm_rc/mod.rs
@@ -1,3 +1,5 @@
+use core::error::Error;
+use core::fmt;
 use core::num::NonZeroU32;
 use core::option::{Option, Option::*};
 use core::result::Result;
@@ -6,8 +8,16 @@ use core::result::Result;
 pub type TpmRcResult<T> = Result<T, TpmRcError>;
 
 /// Represents a TPM 2.0 service error as defined in specification as TPM_RC.
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
 pub struct TpmRcError(NonZeroU32);
+
+impl fmt::Display for TpmRcError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TPM RC error: {:#x}", self.0.get())
+    }
+}
+
+impl Error for TpmRcError {}
 
 // Allow constant to have enum-style case.
 #[allow(non_upper_case_globals)]
@@ -118,9 +128,10 @@ impl TpmRcError {
 }
 
 /// Represents the type of error for a Format1 `TpmRcError` code.
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, Default)]
 pub enum ErrorType {
     /// Error occurred with a Handle.
+    #[default]
     Handle,
     /// Error occurred with a Parameter.
     Parameter,
@@ -156,9 +167,10 @@ impl ErrorType {
 }
 
 /// Represents the positional parameter of the error starting from 1 of a Format1 [`TpmRcError`].
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, Default)]
 pub enum ErrorPosition {
     /// First handle/parameter/session caused the failure.
+    #[default]
     Pos1 = 1,
     /// Second handle/parameter/session caused the failure.
     Pos2,

--- a/crates/tpm2/src/errors/tpm_rc/tests.rs
+++ b/crates/tpm2/src/errors/tpm_rc/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn test_format1() {
-    let error = TpmRcError::AsymmetricFor(ErrorType::Parameter, ErrorPosition::Pos2);
+    let error = TpmRcError::asymmetric_for(ErrorType::Parameter, ErrorPosition::Pos2);
     assert_eq!(error.get(), 0x2C1);
 
     let (on, pos) = error

--- a/crates/tpm2/src/errors/tss_rc.rs
+++ b/crates/tpm2/src/errors/tss_rc.rs
@@ -28,7 +28,7 @@ macro_rules! generate_tss_layer_error {
             pub const NotImplemented: Self = Self::new(6);
             /// Key could not be registered because UUID has already registered
             /// (`TSS_E_KEY_ALREADY_REGISTERED`).
-            pub const KeyAlredyRegistered: Self = Self::new(8);
+            pub const KeyAlreadyRegistered: Self = Self::new(8);
             /// TPM returns with success but TSP/TCS notice that something is wrong
             /// (`TSS_E_TPM_UNEXPECTED`).
             pub const TpmUnexpected: Self = Self::new(16);

--- a/crates/tpm2/src/errors/tss_rc.rs
+++ b/crates/tpm2/src/errors/tss_rc.rs
@@ -1,4 +1,6 @@
 use core::convert::From;
+use core::error::Error;
+use core::fmt;
 use core::num::NonZeroU32;
 use core::option::Option::*;
 use core::result::Result;
@@ -10,8 +12,16 @@ macro_rules! generate_tss_layer_error {
         pub type $result_name<T> = Result<T, $error_name>;
 
         /// Represents a TSS client side error.
-        #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+        #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
         pub struct $error_name(NonZeroU32);
+
+        impl fmt::Display for $error_name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "TSS error: {:#x}", self.0.get())
+            }
+        }
+
+        impl Error for $error_name {}
 
         // Allow constant to have enum-style case.
         #[allow(non_upper_case_globals)]

--- a/crates/tpm2/src/tpmi.rs
+++ b/crates/tpm2/src/tpmi.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// `TPMI_ALG_HASH`
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[repr(u16)]
 #[non_exhaustive]
 pub enum TpmiAlgHash {

--- a/crates/tpm2/src/tpmt.rs
+++ b/crates/tpm2/src/tpmt.rs
@@ -9,7 +9,7 @@ use crate::{
 /// `TPMT_HA`
 ///
 /// There is no type for `TPMU_HA` in this crate, use this type instead.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 #[repr(u16)]
 pub enum TpmtHa<'a> {
     Sha1(&'a [u8; Sha1.digest_size()]) = Alg::Sha1.0,


### PR DESCRIPTION
- Implemented core::fmt::Display and core::error::Error for MarshalError, UnmarshalError, HashError, TssErrorCannotBeZero, TpmRcError, and generated TSS layer errors.
- Derived standard traits (Hash, Default, Eq, Clone) on Alg, TpmiAlgHash, TpmtHa, GetRandom, CmdHeader, RespHeader, PasswordSession, and TCP connection structs/enums.