### PR TITLE
chore: update nightly rust toolchain to 2026-09-01

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
-channel = "nightly-2026-05-14"
+# Update to Rust 1.100 when on Beta/Stable
+channel = "nightly-2026-09-01"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
Update the nightly toolchain channel in rust-toolchain.toml from `nightly-2026-05-14` to `nightly-2026-09-01` ahead of Rust 1.100 stabilization.

We want to target Rust 1.100 as our MSRV and only use stable features from that version (including the `!` type). But that means we will be on nightly until 1.100 is released.