### PR TITLE
Crypto Interfaces

### DIFF
--- a/crates/tpm2/Cargo.toml
+++ b/crates/tpm2/Cargo.toml
@@ -16,6 +16,16 @@ categories.workspace = true
 # Implement conversions/traits which require std
 std = []
 
+# Only enable SHA2 by default
+default = ["sha256", "sha384", "sha512"]
+sha1 = []
+sha256 = []
+sha384 = []
+sha512 = []
+sm3_256 = []
+sha3_256 = []
+sha3_384 = []
+sha3_512 = []
+
 [dependencies]
 bitflags = { workspace = true }
-

--- a/crates/tpm2/src/crypto/hash.rs
+++ b/crates/tpm2/src/crypto/hash.rs
@@ -1,0 +1,203 @@
+use crate::{
+    Alg, TpmiAlgHash, TpmtHa,
+    crypto::{Base, Finalize, Update},
+};
+
+/// Cryptographic hashing interfaces for TPM implementations and clients.
+///
+/// Supported algorithms define a concrete `*Ctx` type and implement:
+///   - A method creating/initializing the context (e.g. [`Hash::sha256()`])
+///   - [`Update<Error>`] for `*Ctx`
+///   - [`Finalize<N, Error>`] for `*Ctx` (where `N` is the digest length)
+///
+/// Unimplemented algorithms bind their context type to [`!`] and
+/// omit the method, keeping the default body of
+/// [`Err(self.unimplemented(...))`](Base::unimplemented).
+///
+/// # Example
+///
+/// ```
+/// # use tpm2::{crypto::{Base, Hash, Finalize, Update}, Alg};
+/// # struct MyBackend;
+/// # struct MyError;
+/// # impl Base for MyBackend {
+/// #   type Error = MyError;
+/// #   fn unimplemented(&self, _: Alg) -> MyError { MyError }
+/// # }
+/// # struct MySha256;
+/// impl Hash for MyBackend {
+///     type Sha256Ctx = MySha256;
+///     fn sha256(&self) -> Result<MySha256, MyError> { todo!() }
+///
+///     // Unsupported algorithms use `!` and default methods:
+///     type Sha1Ctx = !;
+///     type Sha384Ctx = !;
+///     type Sha512Ctx = !;
+///     type Sm3_256Ctx = !;
+///     type Sha3_256Ctx = !;
+///     type Sha3_384Ctx = !;
+///     type Sha3_512Ctx = !;
+/// }
+///
+/// impl Update<MyError> for MySha256 {
+///     fn update(&mut self, data: &[u8]) -> Result<(), MyError> { todo!() }
+/// }
+/// impl Finalize<32, MyError> for MySha256 {
+///     fn finalize(self, out: &mut [u8; 32]) -> Result<(), MyError> { todo!() }
+/// }
+/// ```
+pub trait Hash: Base {
+    type Sha1Ctx: Update<Self::Error> + Finalize<20, Self::Error>;
+    fn sha1(&self) -> Result<Self::Sha1Ctx, Self::Error> {
+        Err(self.unimplemented(Alg::SHA1))
+    }
+
+    type Sha256Ctx: Update<Self::Error> + Finalize<32, Self::Error>;
+    fn sha256(&self) -> Result<Self::Sha256Ctx, Self::Error> {
+        Err(self.unimplemented(Alg::SHA256))
+    }
+
+    type Sha384Ctx: Update<Self::Error> + Finalize<48, Self::Error>;
+    fn sha384(&self) -> Result<Self::Sha384Ctx, Self::Error> {
+        Err(self.unimplemented(Alg::SHA384))
+    }
+
+    type Sha512Ctx: Update<Self::Error> + Finalize<64, Self::Error>;
+    fn sha512(&self) -> Result<Self::Sha512Ctx, Self::Error> {
+        Err(self.unimplemented(Alg::SHA512))
+    }
+
+    type Sm3_256Ctx: Update<Self::Error> + Finalize<32, Self::Error>;
+    fn sm3_256(&self) -> Result<Self::Sm3_256Ctx, Self::Error> {
+        Err(self.unimplemented(Alg::SM3_256))
+    }
+
+    type Sha3_256Ctx: Update<Self::Error> + Finalize<32, Self::Error>;
+    fn sha3_256(&self) -> Result<Self::Sha3_256Ctx, Self::Error> {
+        Err(self.unimplemented(Alg::SHA3_256))
+    }
+
+    type Sha3_384Ctx: Update<Self::Error> + Finalize<48, Self::Error>;
+    fn sha3_384(&self) -> Result<Self::Sha3_384Ctx, Self::Error> {
+        Err(self.unimplemented(Alg::SHA3_384))
+    }
+
+    type Sha3_512Ctx: Update<Self::Error> + Finalize<64, Self::Error>;
+    fn sha3_512(&self) -> Result<Self::Sha3_512Ctx, Self::Error> {
+        Err(self.unimplemented(Alg::SHA3_512))
+    }
+}
+
+/// Dynamic hash context wrapping algorithm-specific streams.
+pub enum HashCtx<H: Hash> {
+    #[cfg(feature = "sha1")]
+    Sha1(H::Sha1Ctx),
+    #[cfg(feature = "sha256")]
+    Sha256(H::Sha256Ctx),
+    #[cfg(feature = "sha384")]
+    Sha384(H::Sha384Ctx),
+    #[cfg(feature = "sha512")]
+    Sha512(H::Sha512Ctx),
+    #[cfg(feature = "sm3_256")]
+    Sm3_256(H::Sm3_256Ctx),
+    #[cfg(feature = "sha3_256")]
+    Sha3_256(H::Sha3_256Ctx),
+    #[cfg(feature = "sha3_384")]
+    Sha3_384(H::Sha3_384Ctx),
+    #[cfg(feature = "sha3_512")]
+    Sha3_512(H::Sha3_512Ctx),
+}
+
+impl<H: Hash> HashCtx<H> {
+    /// Initializes a hash context for `alg` using backend `h`.
+    pub fn new(h: &H, alg: TpmiAlgHash) -> Result<Self, H::Error> {
+        match alg {
+            #[cfg(feature = "sha1")]
+            TpmiAlgHash::Sha1 => h.sha1().map(HashCtx::Sha1),
+            #[cfg(feature = "sha256")]
+            TpmiAlgHash::Sha256 => h.sha256().map(HashCtx::Sha256),
+            #[cfg(feature = "sha384")]
+            TpmiAlgHash::Sha384 => h.sha384().map(HashCtx::Sha384),
+            #[cfg(feature = "sha512")]
+            TpmiAlgHash::Sha512 => h.sha512().map(HashCtx::Sha512),
+            #[cfg(feature = "sm3_256")]
+            TpmiAlgHash::Sm3_256 => h.sm3_256().map(HashCtx::Sm3_256),
+            #[cfg(feature = "sha3_256")]
+            TpmiAlgHash::Sha3_256 => h.sha3_256().map(HashCtx::Sha3_256),
+            #[cfg(feature = "sha3_384")]
+            TpmiAlgHash::Sha3_384 => h.sha3_384().map(HashCtx::Sha3_384),
+            #[cfg(feature = "sha3_512")]
+            TpmiAlgHash::Sha3_512 => h.sha3_512().map(HashCtx::Sha3_512),
+        }
+    }
+
+    /// Feeds `data` into the active hash stream.
+    pub fn update(&mut self, data: &[u8]) -> Result<(), H::Error> {
+        match self {
+            #[cfg(feature = "sha1")]
+            HashCtx::Sha1(ctx) => ctx.update(data),
+            #[cfg(feature = "sha256")]
+            HashCtx::Sha256(ctx) => ctx.update(data),
+            #[cfg(feature = "sha384")]
+            HashCtx::Sha384(ctx) => ctx.update(data),
+            #[cfg(feature = "sha512")]
+            HashCtx::Sha512(ctx) => ctx.update(data),
+            #[cfg(feature = "sm3_256")]
+            HashCtx::Sm3_256(ctx) => ctx.update(data),
+            #[cfg(feature = "sha3_256")]
+            HashCtx::Sha3_256(ctx) => ctx.update(data),
+            #[cfg(feature = "sha3_384")]
+            HashCtx::Sha3_384(ctx) => ctx.update(data),
+            #[cfg(feature = "sha3_512")]
+            HashCtx::Sha3_512(ctx) => ctx.update(data),
+        }
+    }
+
+    /// Finalizes the digest into `out` and returns the tagged [`TpmtHa`].
+    pub fn finalize<'a>(
+        self,
+        out: &'a mut [u8; TpmtHa::MAX_DIGEST_SIZE],
+    ) -> Result<TpmtHa<'a>, H::Error> {
+        /// Helper function for handling finalizing into the output buffer.
+        fn helper<'a, const N: usize, Error>(
+            ctx: impl Finalize<N, Error>,
+            out: &'a mut [u8; TpmtHa::MAX_DIGEST_SIZE],
+        ) -> Result<&'a [u8; N], Error> {
+            const { assert!(N <= TpmtHa::MAX_DIGEST_SIZE) };
+            let digest: &'a mut [u8; N] = out.first_chunk_mut().unwrap();
+            ctx.finalize(digest)?;
+            Ok(digest)
+        }
+
+        match self {
+            #[cfg(feature = "sha1")]
+            HashCtx::Sha1(ctx) => helper(ctx, out).map(TpmtHa::Sha1),
+            #[cfg(feature = "sha256")]
+            HashCtx::Sha256(ctx) => helper(ctx, out).map(TpmtHa::Sha256),
+            #[cfg(feature = "sha384")]
+            HashCtx::Sha384(ctx) => helper(ctx, out).map(TpmtHa::Sha384),
+            #[cfg(feature = "sha512")]
+            HashCtx::Sha512(ctx) => helper(ctx, out).map(TpmtHa::Sha512),
+            #[cfg(feature = "sm3_256")]
+            HashCtx::Sm3_256(ctx) => helper(ctx, out).map(TpmtHa::Sm3_256),
+            #[cfg(feature = "sha3_256")]
+            HashCtx::Sha3_256(ctx) => helper(ctx, out).map(TpmtHa::Sha3_256),
+            #[cfg(feature = "sha3_384")]
+            HashCtx::Sha3_384(ctx) => helper(ctx, out).map(TpmtHa::Sha3_384),
+            #[cfg(feature = "sha3_512")]
+            HashCtx::Sha3_512(ctx) => helper(ctx, out).map(TpmtHa::Sha3_512),
+        }
+    }
+}
+
+/// Computes a digest in a stack-allocated buffer using [`HashCtx`].
+pub fn hash<'a, H: Hash>(
+    h: &H,
+    alg: TpmiAlgHash,
+    data: &[u8],
+    out: &'a mut [u8; TpmtHa::MAX_DIGEST_SIZE],
+) -> Result<TpmtHa<'a>, H::Error> {
+    let mut ctx = HashCtx::new(h, alg)?;
+    ctx.update(data)?;
+    ctx.finalize(out)
+}

--- a/crates/tpm2/src/crypto/mac.rs
+++ b/crates/tpm2/src/crypto/mac.rs
@@ -1,0 +1,3 @@
+use crate::crypto::Base;
+
+pub trait Mac: Base {}

--- a/crates/tpm2/src/crypto/mod.rs
+++ b/crates/tpm2/src/crypto/mod.rs
@@ -1,0 +1,30 @@
+//! Cryptography Interfaces for TPM implementations and clients
+use crate::Alg;
+
+mod hash;
+mod mac;
+pub use {hash::*, mac::*};
+
+pub trait Base {
+    type Error;
+
+    fn unimplemented(&self, alg: Alg) -> Self::Error;
+}
+
+pub trait Update<Error> {
+    fn update(&mut self, data: &[u8]) -> Result<(), Error>;
+}
+pub trait Finalize<const N: usize, Error> {
+    fn finalize(self, out: &mut [u8; N]) -> Result<(), Error>;
+}
+
+impl<Error> Update<Error> for ! {
+    fn update(&mut self, _: &[u8]) -> Result<(), Error> {
+        match *self {}
+    }
+}
+impl<const N: usize, Error> Finalize<N, Error> for ! {
+    fn finalize(self, _: &mut [u8; N]) -> Result<(), Error> {
+        match self {}
+    }
+}

--- a/crates/tpm2/src/lib.rs
+++ b/crates/tpm2/src/lib.rs
@@ -64,6 +64,7 @@
 
 pub mod commands;
 mod constants;
+pub mod crypto;
 pub mod errors;
 mod marshal;
 #[cfg(feature = "std")]

--- a/crates/tpm2/src/structures/tpmi.rs
+++ b/crates/tpm2/src/structures/tpmi.rs
@@ -207,13 +207,21 @@ impl<'a> Unmarshal<'a> for TpmiStCommandTag {
 #[doc(alias = "TPMI_ALG_HASH")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum TpmiAlgHash {
+    #[cfg(feature = "sha1")]
     Sha1 = Alg::SHA1.tag(),
+    #[cfg(feature = "sha256")]
     Sha256 = Alg::SHA256.tag(),
+    #[cfg(feature = "sha384")]
     Sha384 = Alg::SHA384.tag(),
+    #[cfg(feature = "sha512")]
     Sha512 = Alg::SHA512.tag(),
+    #[cfg(feature = "sm3_256")]
     Sm3_256 = Alg::SM3_256.tag(),
+    #[cfg(feature = "sha3_256")]
     Sha3_256 = Alg::SHA3_256.tag(),
+    #[cfg(feature = "sha3_384")]
     Sha3_384 = Alg::SHA3_384.tag(),
+    #[cfg(feature = "sha3_512")]
     Sha3_512 = Alg::SHA3_512.tag(),
 }
 
@@ -221,26 +229,42 @@ impl TpmiAlgHash {
     /// Returns the digest size (in bytes) of this hash algorithm.
     pub const fn digest_size(self) -> usize {
         match self {
+            #[cfg(feature = "sha1")]
             Self::Sha1 => 20,
+            #[cfg(feature = "sha256")]
             Self::Sha256 => 32,
+            #[cfg(feature = "sha384")]
             Self::Sha384 => 48,
+            #[cfg(feature = "sha512")]
             Self::Sha512 => 64,
+            #[cfg(feature = "sm3_256")]
             Self::Sm3_256 => 32,
+            #[cfg(feature = "sha3_256")]
             Self::Sha3_256 => 32,
+            #[cfg(feature = "sha3_384")]
             Self::Sha3_384 => 48,
+            #[cfg(feature = "sha3_512")]
             Self::Sha3_512 => 64,
         }
     }
 
     pub const fn block_size(self) -> u16 {
         match self {
+            #[cfg(feature = "sha1")]
             Self::Sha1 => 64,
+            #[cfg(feature = "sha256")]
             Self::Sha256 => 64,
+            #[cfg(feature = "sha384")]
             Self::Sha384 => 128,
+            #[cfg(feature = "sha512")]
             Self::Sha512 => 128,
+            #[cfg(feature = "sm3_256")]
             Self::Sm3_256 => 64,
+            #[cfg(feature = "sha3_256")]
             Self::Sha3_256 => 136,
+            #[cfg(feature = "sha3_384")]
             Self::Sha3_384 => 104,
+            #[cfg(feature = "sha3_512")]
             Self::Sha3_512 => 72,
         }
     }
@@ -250,13 +274,21 @@ impl TryFrom<Alg> for TpmiAlgHash {
     type Error = UnmarshalError;
     fn try_from(a: Alg) -> Result<TpmiAlgHash, Self::Error> {
         match a {
+            #[cfg(feature = "sha1")]
             Alg::SHA1 => Ok(Self::Sha1),
+            #[cfg(feature = "sha256")]
             Alg::SHA256 => Ok(Self::Sha256),
+            #[cfg(feature = "sha384")]
             Alg::SHA384 => Ok(Self::Sha384),
+            #[cfg(feature = "sha512")]
             Alg::SHA512 => Ok(Self::Sha512),
+            #[cfg(feature = "sm3_256")]
             Alg::SM3_256 => Ok(Self::Sm3_256),
+            #[cfg(feature = "sha3_256")]
             Alg::SHA3_256 => Ok(Self::Sha3_256),
+            #[cfg(feature = "sha3_384")]
             Alg::SHA3_384 => Ok(Self::Sha3_384),
+            #[cfg(feature = "sha3_512")]
             Alg::SHA3_512 => Ok(Self::Sha3_512),
             _ => Err(UnmarshalError),
         }

--- a/crates/tpm2/src/structures/tpmt.rs
+++ b/crates/tpm2/src/structures/tpmt.rs
@@ -13,45 +13,86 @@ use TpmiAlgHash::*;
 #[doc(alias = "TPMU_HA")]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum TpmtHa<'a> {
+    #[cfg(feature = "sha1")]
     Sha1(&'a [u8; Sha1.digest_size()]),
+    #[cfg(feature = "sha256")]
     Sha256(&'a [u8; Sha256.digest_size()]),
+    #[cfg(feature = "sha384")]
     Sha384(&'a [u8; Sha384.digest_size()]),
+    #[cfg(feature = "sha512")]
     Sha512(&'a [u8; Sha512.digest_size()]),
+    #[cfg(feature = "sm3_256")]
     Sm3_256(&'a [u8; Sm3_256.digest_size()]),
+    #[cfg(feature = "sha3_256")]
     Sha3_256(&'a [u8; Sha3_256.digest_size()]),
+    #[cfg(feature = "sha3_384")]
     Sha3_384(&'a [u8; Sha3_384.digest_size()]),
+    #[cfg(feature = "sha3_512")]
     Sha3_512(&'a [u8; Sha3_512.digest_size()]),
 }
 
 impl<'a> TpmtHa<'a> {
     /// The maximum digest size (in bytes) across all supported TPM2 hash algorithms.
-    pub const MAX_DIGEST_SIZE: usize = 64;
+    pub const MAX_DIGEST_SIZE: usize = max(&[
+        #[cfg(feature = "sha1")]
+        Sha1.digest_size(),
+        #[cfg(feature = "sha256")]
+        Sha256.digest_size(),
+        #[cfg(feature = "sha384")]
+        Sha384.digest_size(),
+        #[cfg(feature = "sha512")]
+        Sha512.digest_size(),
+        #[cfg(feature = "sm3_256")]
+        Sm3_256.digest_size(),
+        #[cfg(feature = "sha3_256")]
+        Sha3_256.digest_size(),
+        #[cfg(feature = "sha3_384")]
+        Sha3_384.digest_size(),
+        #[cfg(feature = "sha3_512")]
+        Sha3_512.digest_size(),
+    ]);
     /// The maximum number of implemented hash algorithms.
     #[doc(alias = "TPM2_NUM_PCR_BANKS")]
     pub const HASH_COUNT: usize = 8;
 
     pub const fn hash_alg(self) -> TpmiAlgHash {
         match self {
+            #[cfg(feature = "sha1")]
             Self::Sha1(_) => Sha1,
+            #[cfg(feature = "sha256")]
             Self::Sha256(_) => Sha256,
+            #[cfg(feature = "sha384")]
             Self::Sha384(_) => Sha384,
+            #[cfg(feature = "sha512")]
             Self::Sha512(_) => Sha512,
+            #[cfg(feature = "sm3_256")]
             Self::Sm3_256(_) => Sm3_256,
+            #[cfg(feature = "sha3_256")]
             Self::Sha3_256(_) => Sha3_256,
+            #[cfg(feature = "sha3_384")]
             Self::Sha3_384(_) => Sha3_384,
+            #[cfg(feature = "sha3_512")]
             Self::Sha3_512(_) => Sha3_512,
         }
     }
 
     pub const fn digest(self) -> &'a [u8] {
         match self {
+            #[cfg(feature = "sha1")]
             Self::Sha1(b) => b,
+            #[cfg(feature = "sha256")]
             Self::Sha256(b) => b,
+            #[cfg(feature = "sha384")]
             Self::Sha384(b) => b,
+            #[cfg(feature = "sha512")]
             Self::Sha512(b) => b,
+            #[cfg(feature = "sm3_256")]
             Self::Sm3_256(b) => b,
+            #[cfg(feature = "sha3_256")]
             Self::Sha3_256(b) => b,
+            #[cfg(feature = "sha3_384")]
             Self::Sha3_384(b) => b,
+            #[cfg(feature = "sha3_512")]
             Self::Sha3_512(b) => b,
         }
     }
@@ -72,13 +113,21 @@ impl<'a> Marshal for TpmtHa<'a> {
 impl<'a> Unmarshal<'a> for TpmtHa<'a> {
     fn unmarshal(src: &mut &'a [u8]) -> Result<Self, UnmarshalError> {
         Ok(match TpmiAlgHash::unmarshal(src)? {
+            #[cfg(feature = "sha1")]
             TpmiAlgHash::Sha1 => Self::Sha1(Unmarshal::unmarshal(src)?),
+            #[cfg(feature = "sha256")]
             TpmiAlgHash::Sha256 => Self::Sha256(Unmarshal::unmarshal(src)?),
+            #[cfg(feature = "sha384")]
             TpmiAlgHash::Sha384 => Self::Sha384(Unmarshal::unmarshal(src)?),
+            #[cfg(feature = "sha512")]
             TpmiAlgHash::Sha512 => Self::Sha512(Unmarshal::unmarshal(src)?),
+            #[cfg(feature = "sm3_256")]
             TpmiAlgHash::Sm3_256 => Self::Sm3_256(Unmarshal::unmarshal(src)?),
+            #[cfg(feature = "sha3_256")]
             TpmiAlgHash::Sha3_256 => Self::Sha3_256(Unmarshal::unmarshal(src)?),
+            #[cfg(feature = "sha3_384")]
             TpmiAlgHash::Sha3_384 => Self::Sha3_384(Unmarshal::unmarshal(src)?),
+            #[cfg(feature = "sha3_512")]
             TpmiAlgHash::Sha3_512 => Self::Sha3_512(Unmarshal::unmarshal(src)?),
         })
     }

--- a/crates/tpm2/tests/marshalling.rs
+++ b/crates/tpm2/tests/marshalling.rs
@@ -99,7 +99,7 @@ fn test_2b_struct() {
         pcr_digest: Tpm2bDigest::from_bytes(&[0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9])
             .unwrap(),
         locality: TpmaLocality(0xA),
-        parent_name_alg: Some(TpmiAlgHash::Sha384),
+        parent_name_alg: Some(TpmiAlgHash::Sha256),
         parent_name: Tpm2bName::from_bytes(&[0xA, 0xB, 0xC, 0xD, 0xE, 0xF]).unwrap(),
         parent_qualified_name: Tpm2bName::default(),
         outside_info: Tpm2bData::from_bytes(&[0x1; 32]).unwrap(),
@@ -113,7 +113,7 @@ fn test_2b_struct() {
 fn test_tpml_digest_values_marshalling() {
     let mut lp = TpmlDigestValues::default();
     lp.add(&TpmtHa::Sha256(&[0xaa; 32])).unwrap();
-    lp.add(&TpmtHa::Sha1(&[0xbb; 20])).unwrap();
+    lp.add(&TpmtHa::Sha256(&[0xbb; 32])).unwrap();
 
     let mut buf = [0u8; TpmlDigestValues::MAX_SIZE];
     let len = lp.marshal(&mut buf);
@@ -129,8 +129,8 @@ fn test_tpml_digest_values_marshalling() {
     let mut offset = 4;
     for _ in 0..invalid_count {
         invalid_buf[offset..offset + 2]
-            .copy_from_slice(&Alg::from(TpmiAlgHash::Sha1).id().to_be_bytes());
-        offset += 2 + 20; // 2 bytes alg ID + 20 bytes SHA1 digest
+            .copy_from_slice(&Alg::from(TpmiAlgHash::Sha256).id().to_be_bytes());
+        offset += 2 + 32; // 2 bytes alg ID + 32 bytes SHA256 digest
     }
 
     let mut reader = &invalid_buf[..offset];

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
-channel = "nightly-2026-05-14"
+# Update to Rust 1.100 when on Beta/Stable
+channel = "nightly-2026-09-01"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
This is a draft of how our Crypto interfaces might look.
- A backend defines a `Hash` implementation, which specifies things like:
  - The `Hash::Sha256Ctx` associated type
  - Implementations for:
    - `Hash::sha256()` constructing a `Sha256Ctx`
    - `Sha256Ctx::update()`
    - `Sha256Ctx::finalize()`
  - Uses code like:
    ```rust
    type Sha3_512Ctx = !;
    ```
    to indicate a backend doesn't support `Sha3_512`.
- We then define helper types / functions to handle things like:
  - Init/Update/Finalize hash APIs via `HashCtx`'s `new`/`update`/`finalize` methods.
  - One-shot hashing via:
    ```rust
    pub fn hash<'a, H: Hash>(
        h: &H,
        alg: TpmiAlgHash,
        data: &[u8],
        out: &'a mut [u8; TpmtHa::MAX_DIGEST_SIZE],
    ) -> Result<TpmtHa<'a>, H::Error>
    ```